### PR TITLE
WISH-319-Multi-Stage-Build-Docker-Image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,6 @@ Dockerfile
 .dockerignore
 .git
 .gitignore
-# .env # See env_file in docker-compose.yml
+.env # See env_file in docker-compose.yml
 dist
-# docker/
+docker/

--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,4 @@ global-bundle.pem
 *.tar.gz
 
 # Docker
-docker-compose.yml
 docker/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,41 @@
-# Base image
-FROM node:20
+###
+### Phase 1: builder
+###
 
-# Create app directory
-WORKDIR /usr/src/app
+# Base image
+FROM node:20.18-bookworm-slim AS builder
 
 # Install app dependencies
-COPY package*.json ./
-RUN npm install
-
-# Bundle app source
 COPY . .
+RUN npm install
 
 # Create application build
 RUN npm run build
 
-# Port number
+###
+### Phase 2: runner
+###
+
+FROM node:20.18-bookworm-slim AS runner
+
+# Optimize Node.js tooling for production
+ENV NODE_ENV production
+
 EXPOSE 3000
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Bundle app source
+COPY --from=builder /dist ./dist/
+COPY --from=builder global-bundle.pem ./
+
+# Install production dependencies
+COPY --from=builder /package*.json ./
+RUN npm ci --omit=dev
+
+# Prevent user from run system commands
+USER node
 
 # Start the server
 CMD ["node", "dist/main.js" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  redis:
+    image: redis
+    container_name: giftogether-redis
+    ports:
+      - '6379:6379'
+    volumes:
+      - backup-redis:/data
+      - ./docker/redis.conf:/usr/local/etc/redis/redis.conf
+    command: redis-server /usr/local/etc/redis/redis.conf
+    networks:
+      - g2gnet
+
+  app:
+    image: giftogether:35
+    container_name: giftogether-app
+    ports:
+      - '443:3000'
+    env_file:
+      - .env
+    depends_on:
+      - redis
+    restart: on-failure
+    volumes:
+      - /etc/letsencrypt/live/api.giftogether.co.kr/privkey.pem:/etc/letsencrypt/live/api.giftogether.co.kr/privkey.pem
+      - /etc/letsencrypt/live/api.giftogether.co.kr/fullchain.pem:/etc/letsencrypt/live/api.giftogether.co.kr/fullchain.pem
+    networks:
+      - g2gnet
+
+volumes:
+  backup-redis:
+    external: true
+
+networks:
+  g2gnet:
+    driver: bridge


### PR DESCRIPTION
멀티 스테이지 빌드를 사용하면 최종 이미지 크기를 줄일 수 있다. devDependencies를 포함하지 않고 노드 런타임과 dist 폴더만 존재하는 이미지를 빌드할 경우 얼마나 최적화 할 수 있는지 확인해보자.

## 현재 이미지
```
$ docker images
REPOSITORY          TAG            IMAGE ID       CREATED       SIZE
giftogether-dev     WISH-317       d77b08dfea87   2 days ago    1.49GB
```

```
$ docker image history giftogether-dev:WISH-317
IMAGE          CREATED         CREATED BY                                      SIZE      COMMENT
d77b08dfea87   2 days ago      CMD ["npm" "run" "start:debug"]                 0B        buildkit.dockerfile.v0
<missing>      2 days ago      RUN /bin/sh -c npm install # buildkit           392MB     buildkit.dockerfile.v0
<missing>      2 days ago      COPY . . # buildkit                             711kB     buildkit.dockerfile.v0
<missing>      2 days ago      EXPOSE map[3000/tcp:{}]                         0B        buildkit.dockerfile.v0
<missing>      6 days ago      WORKDIR /usr/src/app                            0B        buildkit.dockerfile.v0
<missing>      3 weeks ago     CMD ["node"]                                    0B        buildkit.dockerfile.v0
<missing>      3 weeks ago     ENTRYPOINT ["docker-entrypoint.sh"]             0B        buildkit.dockerfile.v0
<missing>      3 weeks ago     COPY docker-entrypoint.sh /usr/local/bin/ # …   388B      buildkit.dockerfile.v0
<missing>      3 weeks ago     RUN /bin/sh -c set -ex   && export GNUPGHOME…   5.34MB    buildkit.dockerfile.v0
<missing>      3 weeks ago     ENV YARN_VERSION=1.22.22                        0B        buildkit.dockerfile.v0
<missing>      3 weeks ago     RUN /bin/sh -c ARCH= && dpkgArch="$(dpkg --p…   161MB     buildkit.dockerfile.v0
<missing>      3 weeks ago     ENV NODE_VERSION=20.18.0                        0B        buildkit.dockerfile.v0
<missing>      3 weeks ago     RUN /bin/sh -c groupadd --gid 1000 node   &&…   8.94kB    buildkit.dockerfile.v0
<missing>      9 months ago    RUN /bin/sh -c set -ex;  apt-get update;  ap…   587MB     buildkit.dockerfile.v0
<missing>      9 months ago    RUN /bin/sh -c set -eux;  apt-get update;  a…   177MB     buildkit.dockerfile.v0
<missing>      17 months ago   RUN /bin/sh -c set -eux;  apt-get update;  a…   48.4MB    buildkit.dockerfile.v0
<missing>      17 months ago   /bin/sh -c #(nop)  CMD ["bash"]                 0B
<missing>      17 months ago   /bin/sh -c #(nop) ADD file:b4987bca8c4c4c640…   117MB
```

이미지 중에서 가장 큰 용량을 차지하는 레이어를 뽑아보자면…

- FROM node:20 레이어가 혼자서 거의 1GB를 먹는다.
- RUN npm install 레이어가 392MB를 차지한다.

## 다이어트 결과

1.49GB ⇒ 421MB

```
$ docker images
REPOSITORY    TAG   IMAGE ID       CREATED          SIZE
giftogether   35    098daead2742   3 seconds ago    421MB
```

```
$ docker image history giftogether:35
IMAGE          CREATED              CREATED BY                                      SIZE      COMMENT
098daead2742   About a minute ago   /bin/sh -c #(nop)  CMD ["node" "dist/main.js…   0B
bc879be178e5   About a minute ago   /bin/sh -c npm ci --omit=dev                    220MB
8ed326733f4c   About a minute ago   /bin/sh -c #(nop) COPY multi:7398c0ac27e693c…   1.3MB
42eab01810ba   About a minute ago   /bin/sh -c #(nop) WORKDIR /usr/src/app          0B
92d1bb6d71ac   About a minute ago   /bin/sh -c #(nop)  EXPOSE 3000                  0B
b5c270daf52c   7 minutes ago        /bin/sh -c #(nop)  ENV NODE_ENV=production      0B
b39900045e39   3 weeks ago          CMD ["node"]                                    0B        buildkit.dockerfile.v0
<missing>      3 weeks ago          ENTRYPOINT ["docker-entrypoint.sh"]             0B        buildkit.dockerfile.v0
<missing>      3 weeks ago          COPY docker-entrypoint.sh /usr/local/bin/ # …   388B      buildkit.dockerfile.v0
<missing>      3 weeks ago          RUN /bin/sh -c set -ex   && savedAptMark="$(…   7.18MB    buildkit.dockerfile.v0
<missing>      3 weeks ago          ENV YARN_VERSION=1.22.22                        0B        buildkit.dockerfile.v0
<missing>      3 weeks ago          RUN /bin/sh -c ARCH= OPENSSL_ARCH= && dpkgAr…   117MB     buildkit.dockerfile.v0
<missing>      3 weeks ago          ENV NODE_VERSION=20.18.0                        0B        buildkit.dockerfile.v0
<missing>      3 weeks ago          RUN /bin/sh -c groupadd --gid 1000 node   &&…   8.9kB     buildkit.dockerfile.v0
<missing>      3 weeks ago          /bin/sh -c #(nop)  CMD ["bash"]                 0B
<missing>      3 weeks ago          /bin/sh -c #(nop) ADD file:90b9dd8f12120e8b2…   74.8MB
```

- `RUN npm ci --omit=dev` 레이어가 220MB를 차지한다. 기존에는 392MB를 차지했었다.
- 노드 레이어가 1GB에서 117MB로 10배 감량에 성공했다!
- 의존하는 패키지가 999개에서 456개로 감소했다.



## 10 best practices to containerize Node.js web applications with Docker

ref: <https://snyk.io/blog/10-best-practices-to-containerize-nodejs-web-applications-with-docker/ >

구체적이고 공식적으로 지원하는 이미지 태그를 사용하자. alpine 태그는 비공식이라 피해야 한다. lts라던가 latest는 제로데이 공격에 취약하다.

프로덕션 의존성만을 추가하자. devDependencies를 제외하고 의존성을 설치하는 명령어는 npm ci --only=production 이다.

환경변수를 프로덕션용으로 설정하고 자동으로 런타임이 최적화를 할 수 있도록 하자. ENV NODE_ENV production 

루트권한으로 실행되는 것을 피하자.

도커는 노드 런타임을 PID 1번에 실행한다. 보안상의 위협이 될 수 있으므로 dumb-init CLI를 사용하자. 서버가 비정상적으로 종료되어도 부모 프로세스가 안전하게 시그널을 받아낼 수 있다.

시그널을 받아 Node.js 애플리케이션이 종료될 때 인스턴스들을 안전하게 해제한 뒤에 프로세스를 종료하자.

snyk 광고. 컨테이너가 사용중인 이미지에 취약점이 있는지를 파악해주는 CLI 프로그램이라고.

멀티 스테이지 빌드를 활용하자.

.dockerignore를 사용하자. node_module, .env 파일이 이미지로 올라가는 것을 막는다. .env 파일은 컨테이너화할때 환경변수로 넣어야 한다.

정 시크릿 파일을 이미지로 등록시켜야 한다면 mount secret 옵션을 사용하자.

