### PR TITLE
fix: Add binding for compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - g2gnet
 
   app:
-    image: giftogether:latest
+    image: 975050131958.dkr.ecr.ap-northeast-2.amazonaws.com/coding-jjun/giftogether:latest
     container_name: giftogether-app
     ports:
       - '443:3000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - g2gnet
 
   app:
-    image: giftogether:35
+    image: giftogether:latest
     container_name: giftogether-app
     ports:
       - '443:3000'
@@ -22,6 +22,7 @@ services:
       - redis
     restart: on-failure
     volumes:
+      - ./global-bundle.pem:/usr/src/app/global-bundle.pem
       - /etc/letsencrypt/live/api.giftogether.co.kr/privkey.pem:/etc/letsencrypt/live/api.giftogether.co.kr/privkey.pem
       - /etc/letsencrypt/live/api.giftogether.co.kr/fullchain.pem:/etc/letsencrypt/live/api.giftogether.co.kr/fullchain.pem
     networks:


### PR DESCRIPTION
`app.volumes`에 global-bundle.pem 키를 바인드하도록 추가했습니다. 그리고 `app.image` 이름을 그냥 giftogether가 아닌, 레지스트리까지 포함한 `975050131958.dkr.ecr.ap-northeast-2.amazonaws.com/coding-jjun/giftogether:latest`로 변경하였는데, 아직 태그 latest로의 이미지 덮어씌우기는 이루어지지 않았습니다.