### PR TITLE
WISH-330-tags and image push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - closed
+    # types:
+    #   - closed
 
 jobs:
   build-and-push-image-to-ecr:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5.5.1
         with:
-          images: coding-jjun/giftogether
+          images: ${{secrets.REGISTRY}}/coding-jjun/giftogether
           tags: |
+            type=semver,pattern={{version}}
             type=sha,format=short
             type=raw,value=latest,enable={{is_default_branch}}
       
@@ -45,17 +46,15 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build Docker image
-        run: |
-          docker build -t giftogether -f Dockerfile .
-
-      - name: Tag Docker image
-        run: |
-          # Tag the image with the ECR repository URI
-          docker tag giftogether ${{steps.meta.outputs.tags}}
-          docker tag giftogether coding-jjun/giftogether:latest
+        uses: docker/bake-action@5.10.0
+        with:
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+        targets: build
 
       - name: Push Docker image to ECR
-        run: |
-          # Push the Docker image to your ECR repository
-          docker push ${{secrets.REGISTRY}}/${{ steps.meta.outputs.tags }}
-          docker push ${{secrets.REGISTRY}}/coding-jjun/giftogether:latest
+        uses: docker/build-push-action@v6.9.0
+        with:
+          build-args: |
+            DOCKER_METADATA_OUTPUT_JSON

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,11 +28,14 @@ jobs:
             type=semver,pattern={{version}}
             type=sha,format=short
             type=raw,value=latest,enable={{is_default_branch}}
+          flavor: |
+            latest=true
       
       - name: test metatags
         run: |
             echo "steps.meta.outputs.tags=${{ steps.meta.outputs.tags }}"
             echo "steps.meta.outputs.labels=${{ steps.meta.outputs.labels }}"
+            echo "DOCKER_METADATA_OUTPUT_JSON=${{DOCKER_METADATA_OUTPUT_JSON}}"
 
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -45,16 +48,8 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build Docker image
-        uses: docker/bake-action@v5.10.0
-        with:
-          files: |
-            ./docker-bake.hcl
-            ${{ steps.meta.outputs.bake-file }}
-          targets: build
-
       - name: Push Docker image to ECR
         uses: docker/build-push-action@v6.9.0
         with:
           build-args: |
-            DOCKER_METADATA_OUTPUT_JSON
+            ${{DOCKER_METADATA_OUTPUT_JSON}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-and-push-image-to-ecr:
-    if: ${{ github.event.pull_request.merged == true }}
+    # if: ${{ github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
 
     steps:
@@ -22,8 +22,6 @@ jobs:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5.5.1
-        flavor: |
-          latest=true
         with:
           images: coding-jjun/giftogether
           tags: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
           files: |
             ./docker-bake.hcl
             ${{ steps.meta.outputs.bake-file }}
-        targets: build
+          targets: build
 
       - name: Push Docker image to ECR
         uses: docker/build-push-action@v6.9.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Log in to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@v3
 
       - name: Build and Push
         uses: docker/bake-action@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,9 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=sha,format=short
+            type=ref,event=pr
             type=raw,value=latest,enable={{is_default_branch}}
+
           flavor: |
             latest=true
       

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
             echo "steps.meta.outputs.tags=${{ steps.meta.outputs.tags }}"
             echo "steps.meta.outputs.labels=${{ steps.meta.outputs.labels }}"
-            echo "DOCKER_METADATA_OUTPUT_JSON=$DOCKER_METADATA_OUTPUT_JSON"
+            echo "bake-file: ${{steps.meta.outputs.bake-file}}"
 
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -48,8 +48,11 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Push Docker image to ECR
-        uses: docker/build-push-action@v6.9.0
+      - name: Build and Push
+        uses: docker/bake-action@v5
         with:
-          build-args: |
-            $DOCKER_METADATA_OUTPUT_JSON
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: default
+          push: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,5 +54,4 @@ jobs:
           files: |
             ./docker-bake.hcl
             ${{ steps.meta.outputs.bake-file }}
-          targets: default
           push: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build Docker image
-        uses: docker/bake-action@5.10.0
+        uses: docker/bake-action@v5.10.0
         with:
           files: |
             ./docker-bake.hcl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,9 +51,11 @@ jobs:
       - name: Tag Docker image
         run: |
           # Tag the image with the ECR repository URI
-          docker tag giftogether ${{ secrets.REGISTRY }}${{steps.meta.outputs.tags}}
+          docker tag giftogether ${{steps.meta.outputs.tags}}
+          docker tag giftogether coding-jjun/giftogether:latest
 
       - name: Push Docker image to ECR
         run: |
           # Push the Docker image to your ECR repository
-          docker push ${{ secrets.REGISTRY }}${{ steps.meta.outputs.tags }}
+          docker push ${{secrets.REGISTRY}}${{ steps.meta.outputs.tags }}
+          docker push ${{secrets.REGISTRY}}coding-jjun/giftogether:latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
             echo "steps.meta.outputs.tags=${{ steps.meta.outputs.tags }}"
             echo "steps.meta.outputs.labels=${{ steps.meta.outputs.labels }}"
-            echo "DOCKER_METADATA_OUTPUT_JSON=${{DOCKER_METADATA_OUTPUT_JSON}}"
+            echo "DOCKER_METADATA_OUTPUT_JSON=$DOCKER_METADATA_OUTPUT_JSON"
 
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -52,4 +52,4 @@ jobs:
         uses: docker/build-push-action@v6.9.0
         with:
           build-args: |
-            ${{DOCKER_METADATA_OUTPUT_JSON}}
+            $DOCKER_METADATA_OUTPUT_JSON

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,9 +51,9 @@ jobs:
       - name: Tag Docker image
         run: |
           # Tag the image with the ECR repository URI
-          docker tag giftogether ${{ secrets.REGISTRY }}/coding-jjun/giftogether:${{steps.meta.outputs.tags}}
+          docker tag giftogether ${{ secrets.REGISTRY }}:${{steps.meta.outputs.tags}}
 
       - name: Push Docker image to ECR
         run: |
           # Push the Docker image to your ECR repository
-          docker push ${{ secrets.REGISTRY }}/coding-jjun/giftogether:${{ github.sha }}
+          docker push ${{ secrets.REGISTRY }}:${{ steps.meta.outputs.tags }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
             echo "bake-file: ${{steps.meta.outputs.bake-file}}"
 
       - name: Set up AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,4 +54,5 @@ jobs:
           files: |
             ./docker-bake.hcl
             ${{ steps.meta.outputs.bake-file }}
+          targets: build
           push: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,9 +51,9 @@ jobs:
       - name: Tag Docker image
         run: |
           # Tag the image with the ECR repository URI
-          docker tag giftogether ${{ secrets.REGISTRY }}:${{steps.meta.outputs.tags}}
+          docker tag giftogether ${{ secrets.REGISTRY }}${{steps.meta.outputs.tags}}
 
       - name: Push Docker image to ECR
         run: |
           # Push the Docker image to your ECR repository
-          docker push ${{ secrets.REGISTRY }}:${{ steps.meta.outputs.tags }}
+          docker push ${{ secrets.REGISTRY }}${{ steps.meta.outputs.tags }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,12 @@ jobs:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5.5.1
+        flavor: latest=true
         with:
           images: coding-jjun/giftogether
           tags: |
-            type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=sha,format=short
+            type=raw,value=latest,enable=${{is_default_branch}}
       
       - name: test metatags
         run: |
@@ -50,7 +52,7 @@ jobs:
       - name: Tag Docker image
         run: |
           # Tag the image with the ECR repository URI
-          docker tag giftogether ${{ secrets.REGISTRY }}/coding-jjun/giftogether:${{ github.sha }}
+          docker tag giftogether ${{ secrets.REGISTRY }}/coding-jjun/giftogether:${{steps.meta.outputs.tags}}
 
       - name: Push Docker image to ECR
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5.5.1
-        flavor: latest=true
+        flavor: |
+          latest=true
         with:
           images: coding-jjun/giftogether
           tags: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           images: coding-jjun/giftogether
           tags: |
             type=sha,format=short
-            type=raw,value=latest,enable=${{is_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
       
       - name: test metatags
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,5 +57,5 @@ jobs:
       - name: Push Docker image to ECR
         run: |
           # Push the Docker image to your ECR repository
-          docker push ${{secrets.REGISTRY}}${{ steps.meta.outputs.tags }}
-          docker push ${{secrets.REGISTRY}}coding-jjun/giftogether:latest
+          docker push ${{secrets.REGISTRY}}/${{ steps.meta.outputs.tags }}
+          docker push ${{secrets.REGISTRY}}/coding-jjun/giftogether:latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
             echo "steps.meta.outputs.labels=${{ steps.meta.outputs.labels }}"
 
       - name: Set up AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,11 @@
+// docker-bake.hcl
+target "docker-metadata-action" {}
+
+target "build" {
+  inherits = ["docker-metadata-action"]
+  context = "./"
+  dockerfile = "Dockerfile"
+  platforms = [
+    "linux/amd64"
+  ]
+}


### PR DESCRIPTION
# GitHub 워크플로우에서 Docker 이미지 메타데이터 및 빌드 자동화 개선

이 PR은 GitHub Actions 워크플로우 내에서 Docker 이미지 빌드 및 배포 프로세스를 개선합니다. 주요 변경 사항에는 `docker-bake.hcl` 구성 파일 도입, 동적 태깅 전략, 효율적인 메타데이터 및 빌드 액션 전환이 포함됩니다.

## 주요 변경 사항

### 1. GitHub Actions 워크플로우 (`deploy.yml`)
- **동적 이미지 태깅**: `docker/metadata-action` 설정을 통해 여러 태깅 패턴(`semver`, `sha`, 브랜치 기반)을 사용하여 이미지를 동적으로 태깅하도록 업데이트했습니다.
- **레지스트리 시크릿 통합**: 이미지 경로의 하드코딩을 `${{ secrets.REGISTRY }}`로 대체하여 레지스트리 자격 증명을 중앙에서 관리함으로써 보안과 유연성을 강화했습니다.
- **효율적인 Docker 이미지 빌드 및 푸시**: `docker/bake-action@v5`를 사용해 빌드 및 푸시 단계를 통합하고, 별도의 Docker Bake 설정 파일(`docker-bake.hcl`)에서 타겟을 지정하여 워크플로우를 간소화하고 다중 플랫폼 빌드를 지원했습니다.

### 2. Docker Bake 구성 (`docker-bake.hcl`)
- **새로운 Docker Bake 파일**: Docker 이미지에 대해 빌드 컨텍스트, Dockerfile 위치 및 플랫폼 타겟을 구성하는 `docker-bake.hcl` 파일을 도입했습니다. 이 구성 파일은 다중 플랫폼 지원(예: `linux/amd64`)을 가능하게 하고, 각 단계에 일관된 빌드 매개변수를 재사용할 수 있게 합니다.

### 기대 효과
- **보안 및 유연성 강화**: 레지스트리 자격 증명을 중앙 관리하고 이미지를 동적으로 태깅하여 더 안전하고 유연한 워크플로우가 가능합니다.
- **워크플로우 간소화**: Docker Bake 파일을 통해 다중 플랫폼 빌드의 복잡성을 줄이고 빌드 및 푸시 프로세스를 간소화했습니다.

## 관련 스크린샷

**ECR에 이미지가 두개의 태그를 달고 올라온 모습**

<img width="1106" alt="Screenshot 2024-11-15 at 00 26 14" src="https://github.com/user-attachments/assets/8fb5dca3-0da1-4818-b424-25e53ede57cd">
