### PR TITLE
WISH-332-Image-Url-Duplication-Is_Ok

### DIFF
--- a/src/features/image/image.service.ts
+++ b/src/features/image/image.service.ts
@@ -11,7 +11,7 @@ export class ImageService {
   constructor(
     @InjectRepository(Image) private readonly imgRepo: Repository<Image>,
     private readonly g2gException: GiftogetherExceptions,
-  ) {}
+  ) { }
 
   async getInstancesBySubId(
     imgType: ImageType,
@@ -75,7 +75,9 @@ export class ImageService {
       return foundImg;
     }
 
-    throw this.g2gException.ImageAlreadyExists;
+    // OK if foundImg duplicates, just make sure subId related into another instance
+    const duplicatedImg = new Image(imgUrl, imgType, subId, creator);
+    return this.imgRepo.save(duplicatedImg);
   }
 
   /**


### PR DESCRIPTION
---

### PR 설명: `ImageService`에서 중복 이미지 레코드 처리

#### 요약
이 PR은 데이터베이스에 동일한 `imgUrl`과 `creator`가 존재하는 경우 중복 이미지 레코드를 더 유연하게 처리할 수 있도록 `ImageService` 클래스에 수정 사항을 추가합니다.

#### 주요 변경 사항
1. **중복 이미지 처리**:
   - 동일한 URL의 이미지가 이미 사용자에게 존재하는 경우를 처리하는 로직을 추가했습니다.
     - 중복 이미지가 발견되었을 때 `ImageAlreadyExists` 예외를 발생시키는 대신, 동일한 `imgUrl`, `imgType`, 및 `subId`로 새로운 `Image` 인스턴스를 생성할 수 있도록 변경했습니다.
     - 이러한 수정은 같은 이미지 URL이 여러 레코드에서 참조될 수 있도록 허용하여 데이터 무결성을 유지하면서 더 많은 유연성을 제공합니다.

#### 기대 효과
- 이 업데이트를 통해 중복 이미지 관리를 보다 유연하게 하여, 동일한 이미지를 여러 레코드에서 참조해야 하는 시나리오를 지원할 수 있습니다.
  
#### 테스트 및 검증
- 이번 수정 사항이 올바르게 동작하는지 검증하기 위해 다음 사항을 테스트해야 합니다:
  - 별도의 인스턴스로 중복 이미지가 올바르게 생성되는지.
  - 각 경우에서 `subId` 및 `imgType`이 올바르게 연관되는지.

**Before**

<img width="632" alt="WISH-332-Before" src="https://github.com/user-attachments/assets/9dbc95aa-9829-4d97-b28e-f40d2f73b814">

**After**

<img width="651" alt="WISH-332-After" src="https://github.com/user-attachments/assets/137fc897-1d4d-484d-a57f-c1bf3c718fde">

**DBeaver Result**

<img width="379" alt="WISH-332-dbeaver-result" src="https://github.com/user-attachments/assets/ea663512-8903-43e7-b296-7910754a7283">


#### 향후 고려 사항
- 향후 요구사항에 따라 중복 관리를 더욱 엄격하게 할 필요가 있을 경우 추가 제약을 구현하는 것도 고려할 수 있습니다.

---

이번 PR은 Giftogether 백엔드에서 중복 이미지 레코드를 보다 유연하게 처리할 수 있도록 개선하여, 데이터 일관성을 유지하면서 필요한 경우 중복 항목을 허용하는 방향으로 조정합니다.