### PR TITLE
Notification

### DIFF
--- a/src/entities/notification.entity.ts
+++ b/src/entities/notification.entity.ts
@@ -31,4 +31,7 @@ export class Notification {
 
   @CreateDateColumn()
   notiTime: Date;
+
+  @Column({ default: false })
+  isRead: boolean;
 }

--- a/src/features/notification/dto/notification.dto.ts
+++ b/src/features/notification/dto/notification.dto.ts
@@ -10,6 +10,7 @@ export class NotiDto {
   notiType: NotiType;
   subId: string;
   notiTime: Date;
+  isRead: boolean;
   fundTitle?: string;
 
   constructor(notification: Notification) {
@@ -21,6 +22,7 @@ export class NotiDto {
     this.notiType = notification.notiType;
     this.subId = notification.subId;
     this.notiTime = notification.notiTime;
+    this.isRead = notification.isRead;
     this.fundTitle = undefined;
   }
 }

--- a/src/features/notification/notification.controller.ts
+++ b/src/features/notification/notification.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Param,
   ParseIntPipe,
+  Patch,
   Post,
   Put,
   Query,
@@ -40,6 +41,23 @@ export class NotificationController {
 
       return {
         data: await this.notiService.getAllNoti(user.userId, notiFilter, lastId),
+      };
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  @Patch('/read')
+  @UseGuards(JwtAuthGuard)
+  async readNoti(
+    @Req() req: Request,
+    @Body('lastTime') lastTime: Date,
+  ): Promise<CommonResponse> {
+    try {
+      const user = req.user as { user: User } as any;
+      
+      return {
+        data: await this.notiService.readNoti(lastTime, user.userId)
       };
     } catch (error) {
       throw error;

--- a/src/features/notification/notification.controller.ts
+++ b/src/features/notification/notification.controller.ts
@@ -64,6 +64,22 @@ export class NotificationController {
     }
   }
 
+  @Get('/read')
+  @UseGuards(JwtAuthGuard)
+  async checkUnread(
+    @Req() req: Request
+  ): Promise<CommonResponse> {
+    try {
+      const user = req.user as { user: User } as any;
+
+      return {
+        data: await this.notiService.checkUnread(user.userId)
+      }
+    } catch (error) {
+      throw error;
+    }
+  }
+
   // @Post('')
   // @UseGuards(JwtAuthGuard)
   // async create(

--- a/src/features/notification/notification.service.ts
+++ b/src/features/notification/notification.service.ts
@@ -354,4 +354,17 @@ export class NotificationService {
       }
     }
   }
+
+  async readNoti(
+    lastTime: Date,
+    userId: number,
+  ): Promise<void> {
+    await this.notiRepository.createQueryBuilder()
+    .update(Notification)
+    .set({ isRead: true })
+    .where('recvId = :userId', { userId })
+    .andWhere('notiTime <= :lastTime', { lastTime })
+    .andWhere('isRead = false')
+    .execute();
+  }
 }

--- a/src/features/notification/notification.service.ts
+++ b/src/features/notification/notification.service.ts
@@ -367,4 +367,16 @@ export class NotificationService {
     .andWhere('isRead = false')
     .execute();
   }
+
+  async checkUnread(
+    userId: number,
+  ): Promise<boolean> {
+    const lastNotification = await this.notiRepository
+    .createQueryBuilder('notification')
+    .where('notification.recvId = :userId', { userId })
+    .orderBy('notification.notiTime', 'DESC')
+    .getOne();
+
+    return lastNotification ? !lastNotification.isRead : false;
+  }
 }

--- a/src/features/notification/notification.service.ts
+++ b/src/features/notification/notification.service.ts
@@ -359,11 +359,14 @@ export class NotificationService {
     lastTime: Date,
     userId: number,
   ): Promise<void> {
+    const newTime = new Date(lastTime);
+    const utcLastTime = new Date(newTime.getTime() - newTime.getTimezoneOffset() * 60000);
+    
     await this.notiRepository.createQueryBuilder()
     .update(Notification)
     .set({ isRead: true })
     .where('recvId = :userId', { userId })
-    .andWhere('notiTime <= :lastTime', { lastTime })
+    .andWhere('notiTime <= :utcLastTime', { utcLastTime })
     .andWhere('isRead = false')
     .execute();
   }


### PR DESCRIPTION
- Notification Entity에 isRead Column 추가

- PATCH /notification/read API 추가
  > 알림 히스토리 페이지 방문시각 이전에 생성된 읽지 않은 알림 모두 읽음 상태로 변경

- GET /notification/read API 추가
  > 마지막으로 생성된 알림의 읽음 상태 조회
  > 읽지 않은 알림이 있으면 true 반환
  > 읽지 않은 알림이 없으면 false 반환