### PR TITLE
WISH-339-auto-git-pull-on-ec2

### DIFF
--- a/.github/workflows/deploy-to-ec2.yml
+++ b/.github/workflows/deploy-to-ec2.yml
@@ -31,8 +31,10 @@ jobs:
         name: Deploy application
         run: |
           ssh -o StrictHostKeyChecking=no ubuntu@${{ secrets.EC2_HOST }} << 'EOF'
-
+          
           cd ~/wishlist_funding_backend/
+          git fetch -ap
+          get merge origin main
           ./auto-deploy.sh
           EOF
 


### PR DESCRIPTION
## 작업 목적

본 코드수정은 EC2에서 최신화 되어있지 않은 파일, 특히 auto-deploy.sh 를 사전에 미리 동기화 한 후 배포를 진행하기 위해 필요합니다.