### PR TITLE
WISH-369 Fix: /comment GET API authorName problem 해결 🎉

### DIFF
--- a/src/features/comment/comment.service.ts
+++ b/src/features/comment/comment.service.ts
@@ -1,9 +1,9 @@
-import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
 import { Comment } from 'src/entities/comment.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Equal, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { Funding } from 'src/entities/funding.entity';
 import { GetCommentDto } from './dto/get-comment.dto';
 import { User } from 'src/entities/user.entity';
@@ -13,8 +13,7 @@ import { ValidCheck } from 'src/util/valid-check';
 
 function convertToGetCommentDto(comment: Comment): GetCommentDto {
   const { comId, content, regAt, isMod, authorId, author } = comment;
-  Logger.log(`comment: ${JSON.stringify(comment)}`);
-  const authorName = author?.userName || 'ANONYMOUS';
+  const authorName = author?.userName ?? 'ANONYMOUS';
   return new GetCommentDto(comId, content, regAt, isMod, authorId, authorName);
 }
 

--- a/src/features/comment/comment.service.ts
+++ b/src/features/comment/comment.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
 import { Comment } from 'src/entities/comment.entity';
@@ -13,7 +13,8 @@ import { ValidCheck } from 'src/util/valid-check';
 
 function convertToGetCommentDto(comment: Comment): GetCommentDto {
   const { comId, content, regAt, isMod, authorId, author } = comment;
-  const authorName = author?.userName ?? 'ANONYMOUS';
+  Logger.log(`comment: ${JSON.stringify(comment)}`);
+  const authorName = author?.userName || 'ANONYMOUS';
   return new GetCommentDto(comId, content, regAt, isMod, authorId, authorName);
 }
 
@@ -79,6 +80,7 @@ export class CommentService {
         'comment.isDel = :isDel',
         { isDel: false },
       )
+      .leftJoinAndSelect('comment.author', 'author')
       .where('funding.fundUuid = :fundUuid', { fundUuid })
       .orderBy('comment.regAt', 'DESC')
       .getOne();


### PR DESCRIPTION
## 댓글 응답에서 “ANONYMOUS” 작성자 이름 문제 해결

이 PR은 Giftogether 서비스에서 댓글 응답의 authorName 속성이 항상 “ANONYMOUS”로 표시되던 버그를 수정합니다. 댓글을 조회하는 쿼리에서 author 관계를 올바르게 조인하도록 수정하여 이 문제를 해결했습니다.

변경 사항:

CommentService의 getComment 쿼리에 author 관계에 대한 leftJoinAndSelect를 추가했습니다.

수정 전:

모든 응답에서 authorName이 실제 사용자와 관계없이 “ANONYMOUS”로 잘못 표시되었습니다.

```json
{
    "timestamp": "2024-11-27T22:11:03.728Z",
    "message": "success",
    "data": [
        {
            "comId": 108,
            "content": "Aut at veritatis totam. Ab reprehenderit dolor quod harum tempora provident aut quo et. Dolore corrupti laboriosam quo libero ex sit saepe. Animi amet modi eos sit doloremque est rerum. In delectus aut quae.",
            "regAt": "2024-11-27T04:10:59.785Z",
            "isMod": false,
            "authorId": 140,
            "authorName": "ANONYMOUS"
        }
    ]
}
```

수정 후:

authorName이 이제 댓글 작성자의 이름을 정확히 반영합니다.

```json
{
    "timestamp": "2024-11-30T21:39:57.806Z",
    "message": "success",
    "data": [
        {
            "comId": 113,
            "content": "Laudantium a autem quod velit. Id cum dolores quis nostrum. Assumenda occaecati sed. Nam et voluptas quo illum aut.",
            "regAt": "2024-11-27T08:06:19.992Z",
            "isMod": false,
            "authorId": 140,
            "authorName": "최승현-WISH-334"
        }
    ]
}
```


이번 수정으로 API 응답에서 더 정확하고 사용자 친화적인 댓글 데이터를 제공할 수 있게 되었습니다.