### PR TITLE
WISH-360-defaultImgIdImgId

### DIFF
--- a/src/entities/funding.entity.ts
+++ b/src/entities/funding.entity.ts
@@ -136,6 +136,7 @@ export class Funding implements IImageId {
    */
   @Column('int', { nullable: true })
   @OneToOne(() => Image, (image) => image.imgId)
+  @JoinColumn({ name: 'defaultImgId' })
   defaultImgId?: number;
 
   @OneToOne(() => Image, (image) => image.subId)

--- a/src/entities/gift.entity.ts
+++ b/src/entities/gift.entity.ts
@@ -44,5 +44,6 @@ export class Gift implements IImageId {
 
   @Column({ nullable: true })
   @ManyToOne(() => Image, (image) => image.imgId)
+  @JoinColumn({ name: 'defaultImgId' })
   defaultImgId?: number;
 }

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -83,6 +83,7 @@ export class User implements IImageId {
 
   @Column('int', { nullable: true })
   @OneToOne(() => Image, (image) => image.imgId)
+  @JoinColumn({ name: 'defaultImgId' })
   defaultImgId?: number;
 
   @OneToMany(() => Image, (image) => image.creator)


### PR DESCRIPTION
---

### 수정: 데이터베이스 스키마에서 예상치 못한 "defaultImgIdImgId" 열 제거

이 PR은 Giftogether 서비스에서 엔티티 관계 설정 문제로 인해 데이터베이스 스키마에 예상치 못한 `defaultImgIdImgId` 열이 생성되는 문제를 해결합니다. 영향을 받는 엔티티에서 `@JoinColumn` 데코레이터를 사용하여 올바른 열 이름(`defaultImgId`)을 명시적으로 지정하여 문제를 해결했습니다.

#### 변경 사항:
- 다음 엔티티의 `defaultImgId` 속성에 `@JoinColumn({ name: 'defaultImgId' })` 추가:
  - `Funding`
  - `Gift`
  - `User`

#### 수정 전:
데이터베이스 스키마에 불필요하고 의도하지 않은 `defaultImgIdImgId` 열이 생성되었습니다.

**gift**

```
pg:postgres@db-server/postgres=> \d gift
                                      table "public.gift"
       Name        |         Type          | Nullable |                Default
-------------------+-----------------------+----------+----------------------------------------
 giftId            | integer               | "NO"     | nextval('"gift_giftId_seq"'::regclass)
 giftUrl           | character varying     | "NO"     |
 giftOrd           | integer               | "NO"     |
 giftOpt           | character varying     | "YES"    |
 giftCont          | character varying(20) | "YES"    |
 defaultImgId      | integer               | "YES"    |
 fundId            | integer               | "YES"    |
 giftTitle         | character varying     | "NO"     |
 defaultImgIdImgId | integer               | "YES"    |
```

**funding**

엥? 없네..

```
pg:postgres@db-server/postgres=> \d funding
                                        table "public.funding"
     Name      |              Type              | Nullable |                  Default
---------------+--------------------------------+----------+-------------------------------------------
 fundId        | integer                        | "NO"     | nextval('"funding_fundId_seq"'::regclass)
 fundUuid      | uuid                           | "NO"     | uuid_generate_v4()
 fundTitle     | character varying              | "NO"     |
 fundCont      | character varying              | "NO"     |
 fundTheme     | USER-DEFINED                   | "NO"     | 'Birthday'::funding_fundtheme_enum
 fundPubl      | boolean                        | "NO"     | true
 fundGoal      | integer                        | "NO"     |
 fundSum       | integer                        | "NO"     | 0
 fundAddrRoad  | character varying              | "NO"     |
 fundAddrDetl  | character varying              | "NO"     |
 fundAddrZip   | character varying              | "NO"     |
 fundRecvName  | character varying              | "NO"     |
 fundRecvPhone | character varying              | "NO"     |
 fundRecvReq   | character varying              | "YES"    |
 endAt         | date                           | "NO"     |
 regAt         | timestamp(6) without time zone | "NO"     | now()
 uptAt         | timestamp(6) without time zone | "NO"     | now()
 defaultImgId  | integer                        | "YES"    |
 fundUser      | integer                        | "YES"    |
```

**user**

엥.. 얘도 없넹?

```
pg:postgres@db-server/postgres=> \d user
                                        table "public.user"
     Name     |              Type              | Nullable |                Default
--------------+--------------------------------+----------+----------------------------------------
 userId       | integer                        | "NO"     | nextval('"user_userId_seq"'::regclass)
 userNick     | character varying              | "YES"    |
 userPw       | character varying              | "YES"    |
 userName     | character varying              | "YES"    |
 userPhone    | character varying              | "YES"    |
 userEmail    | character varying              | "YES"    |
 userBirth    | date                           | "YES"    |
 regAt        | timestamp(6) without time zone | "NO"     | now()
 uptAt        | timestamp(6) without time zone | "NO"     | now()
 delAt        | timestamp(6) without time zone | "YES"    |
 userAcc      | integer                        | "YES"    |
 defaultImgId | integer                        | "YES"    |
 authId       | character varying              | "YES"    |
 authType     | character varying              | "NO"     | 'Jwt'::character varying
```

#### 수정 후:

스키마가 이제 예상대로 `defaultImgId`를 올바르게 사용하며, 불필요한 열이 제거되었습니다.

**gift**

gift 하나만 제대로 된건가 봅니다

```
pg:postgres@db-server/dev1=> \d gift
                                   table "public.gift"
     Name     |         Type          | Nullable |                Default
--------------+-----------------------+----------+----------------------------------------
 giftId       | integer               | "NO"     | nextval('"gift_giftId_seq"'::regclass)
 giftTitle    | character varying     | "NO"     |
 giftUrl      | character varying     | "NO"     |
 giftOrd      | integer               | "NO"     |
 giftOpt      | character varying     | "YES"    |
 giftCont     | character varying(20) | "YES"    |
 defaultImgId | integer               | "YES"    |
 fundId       | integer               | "YES"    |
```

**funding**

```
pg:postgres@db-server/dev1=> \d funding
                                        table "public.funding"
     Name      |              Type              | Nullable |                  Default
---------------+--------------------------------+----------+-------------------------------------------
 fundId        | integer                        | "NO"     | nextval('"funding_fundId_seq"'::regclass)
 fundUuid      | uuid                           | "NO"     | uuid_generate_v4()
 fundTitle     | character varying              | "NO"     |
 fundCont      | character varying              | "NO"     |
 fundTheme     | USER-DEFINED                   | "NO"     | 'Birthday'::funding_fundtheme_enum
 fundPubl      | boolean                        | "NO"     | true
 fundGoal      | integer                        | "NO"     |
 fundSum       | integer                        | "NO"     | 0
 fundAddrRoad  | character varying              | "NO"     |
 fundAddrDetl  | character varying              | "NO"     |
 fundAddrZip   | character varying              | "NO"     |
 fundRecvName  | character varying              | "NO"     |
 fundRecvPhone | character varying              | "NO"     |
 fundRecvReq   | character varying              | "YES"    |
 endAt         | date                           | "NO"     |
 regAt         | timestamp(6) without time zone | "NO"     | now()
 uptAt         | timestamp(6) without time zone | "NO"     | now()
 defaultImgId  | integer                        | "YES"    |
 fundUser      | integer                        | "YES"    |
```

**user**

```
pg:postgres@db-server/dev1=> \d user
                                        table "public.user"
     Name     |              Type              | Nullable |                Default
--------------+--------------------------------+----------+----------------------------------------
 userId       | integer                        | "NO"     | nextval('"user_userId_seq"'::regclass)
 authId       | character varying              | "YES"    |
 authType     | character varying              | "NO"     | 'Jwt'::character varying
 userNick     | character varying              | "YES"    |
 userPw       | character varying              | "YES"    |
 userName     | character varying              | "YES"    |
 userPhone    | character varying              | "YES"    |
 userEmail    | character varying              | "YES"    |
 userBirth    | date                           | "YES"    |
 regAt        | timestamp(6) without time zone | "NO"     | now()
 uptAt        | timestamp(6) without time zone | "NO"     | now()
 delAt        | timestamp(6) without time zone | "YES"    |
 defaultImgId | integer                        | "YES"    |
 userAcc      | integer                        | "YES"    |
```

이번 수정으로 데이터베이스 스키마가 명확하고 예측 가능한 형태로 정리되었으며, 엔티티 설계와 일치하게 되었습니다.

## CAUTION

이 수정은 데이터베이스 테이블에 `ALTER` 명령을 보내게 됩니다. 현재 `dev1` 데이터베이스에 테스트 완료하였으며, 머지 완료시 CI/CD 스크립트에 의해 자동으로 `postgre` 데이터베이스에 영향이 가게 될 예정입니다. **실패할 가능성이 있습니다** 꼭 EC2 로그를 확인해야 합니다.