### PR TITLE
WISH-374-cors_origin

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import * as fs from 'fs';
 import * as cookieParser from 'cookie-parser';
+import { ConfigService } from '@nestjs/config';
 
 async function bootstrap() {
   const port = process.env.PORT;
@@ -33,11 +34,21 @@ async function bootstrap() {
 
   const app = await NestFactory.create(AppModule, nestFactoryOptions);
 
+  const configService = app.get(ConfigService);
   app.useGlobalPipes(new ValidationPipe({ transform: true }));
   app.use(cookieParser());
   app.enableCors({
-    origin: process.env.CORS_ORIGIN, // 쿠키가 설정될 도메인
-    credentials: true // 자격 증명이 포함된 요청을 허용
+    origin: (origin, callback) => {
+      const allowedOrigins = configService
+        .get<string>('CORS_ORIGIN')
+        .split(',');
+      if (allowedOrigins.includes(origin) || !origin) {
+        callback(null, true);
+      } else {
+        callback(new Error('Not allowed by CORS'));
+      }
+    },
+    credentials: true, // 자격 증명이 포함된 요청을 허용
   });
   await app.listen(port);
 }


### PR DESCRIPTION
# NestJS 애플리케이션의 CORS 정책 업데이트

이 PR은 NestJS 프로젝트의 `src/main.ts` 파일에서 CORS 정책 구성을 수정하여 유연성과 보안을 강화합니다. 기존의 정적인 `CORS_ORIGIN` 설정을 보다 강력한 검증 로직으로 대체하여 동적으로 처리합니다.

## 변경 사항
- **동적 Origin 검증:**  
  이제 `CORS_ORIGIN` 환경 변수를 쉼표로 구분된 허용된 Origin 목록으로 구문 분석합니다. 이 목록은 들어오는 요청에 대해 동적으로 검증됩니다.
- **향상된 오류 처리:**  
  허용된 목록에 없는 Origin에서의 요청은 `Not allowed by CORS`라는 설명이 포함된 오류 메시지를 반환합니다.
- **의존성 주입 사용:**  
  `ConfigService`를 활용하여 `CORS_ORIGIN` 환경 변수를 가져오고 구문 분석하며, NestJS의 의존성 주입 시스템을 통해 더 나은 설정 가능성과 모듈화를 제공합니다.

## 변경 이유
- **보안 강화:** 동적 검증을 통해 명시적으로 허용된 Origin만 요청을 보낼 수 있도록 하여, 허가되지 않은 크로스 오리진 접근 위험을 줄입니다.
- **유연성:** 이제 `CORS_ORIGIN` 환경 변수에 쉼표로 구분된 여러 Origin을 지정할 수 있습니다.
- **유지 보수성:** `ConfigService`를 통해 중앙 집중식 구성 관리를 수행하여 확장 가능하고 유지 보수 가능한 애플리케이션의 모범 사례를 따릅니다.

## 테스트 방법
1. `CORS_ORIGIN` 환경 변수에 허용된 Origin 목록을 쉼표로 구분하여 설정합니다(예: `http://example.com,http://anotherdomain.com`).
2. 서버를 시작한 후, 다음을 테스트합니다:
   - 허용된 Origin: 요청이 성공하고 쿠키가 제대로 처리되는지 확인합니다.
   - 허용되지 않은 Origin: 적절한 오류 메시지가 반환되는지 확인합니다.
3. 단일 Origin 또는 Origin이 비어 있는 시나리오를 테스트하여 이전과의 호환성을 확인합니다.

httpie를 사용하여 헤더에 `Origin:...` 을 추가하여 요청을 던져본 결과:

origin이 등록이 안된 경우 실패합니다:

```
$ http http://localhost:3000 Origin:http://www.giftogether.co.kr
HTTP/1.1 500 Internal Server Error
Connection: keep-alive
Content-Length: 84
Content-Type: application/json; charset=utf-8
Date: Sat, 30 Nov 2024 14:07:37 GMT
ETag: W/"54-jAiDGPXgoFtS7T+tSmV0GFa7iMM"
Keep-Alive: timeout=5
X-Powered-By: Express

{
    "data": null,
    "message": "Not allowed by CORS",
    "timestamp": "2024-11-30T23:07:37.445Z"
}
```

아래 두 케이스는 `.env` 파일에 콤마로 분리해놓은 `CORS_ORIGIN` 값을 테스트한 결과입니다.

```
$ http http://localhost:3000 Origin:http://localhost:3000
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: http://localhost:3000
Connection: keep-alive
Content-Length: 60
Content-Type: application/json; charset=utf-8
Date: Sat, 30 Nov 2024 14:07:53 GMT
ETag: W/"3c-ws0K5/5yagu44ID8ZleQTsdsn6g"
Keep-Alive: timeout=5
Vary: Origin
X-Powered-By: Express

{
    "message": "Success",
    "timestamp": "2024-11-30T23:07:53.264Z"
}


$ http http://localhost:3000 Origin:https://www.giftogether.co.kr
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: https://www.giftogether.co.kr
Connection: keep-alive
Content-Length: 60
Content-Type: application/json; charset=utf-8
Date: Sat, 30 Nov 2024 14:08:11 GMT
ETag: W/"3c-zWZGBjoD848HrTAcUf4dxz8Elwc"
Keep-Alive: timeout=5
Vary: Origin
X-Powered-By: Express

{
    "message": "Success",
    "timestamp": "2024-11-30T23:08:11.119Z"
}
```

## ⚠️  추가로 필요로 하는 작업 

EC2 `.env` 파일이 수정되어야 합니다. 