### PR TITLE
FIX-defaultImgId

### DIFF
--- a/src/entities/funding.entity.ts
+++ b/src/entities/funding.entity.ts
@@ -135,7 +135,7 @@ export class Funding implements IImageId {
    * defaultImgId가 null인 경우, Image.subId로 이미지를 가져올 수 있습니다.
    */
   @Column('int', { nullable: true })
-  @OneToOne(() => Image, (image) => image.imgId)
+  @ManyToOne(() => Image, (image) => image.imgId)
   @JoinColumn({ name: 'defaultImgId' })
   defaultImgId?: number;
 

--- a/src/entities/gift.entity.ts
+++ b/src/entities/gift.entity.ts
@@ -42,7 +42,7 @@ export class Gift implements IImageId {
   @Column({ nullable: true, length: 20 })
   giftCont: string;
 
-  @Column({ nullable: true })
+  @Column('int', { nullable: true })
   @ManyToOne(() => Image, (image) => image.imgId)
   @JoinColumn({ name: 'defaultImgId' })
   defaultImgId?: number;

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -8,6 +8,7 @@ import {
   OneToMany,
   OneToOne,
   JoinColumn,
+  ManyToOne,
 } from 'typeorm';
 import { Funding } from './funding.entity';
 import { Comment } from './comment.entity';
@@ -82,7 +83,7 @@ export class User implements IImageId {
   user: Promise<Date>;
 
   @Column('int', { nullable: true })
-  @OneToOne(() => Image, (image) => image.imgId)
+  @ManyToOne(() => Image, (image) => image.imgId)
   @JoinColumn({ name: 'defaultImgId' })
   defaultImgId?: number;
 


### PR DESCRIPTION
`@OneToOne` 데코레이터가 자동으로 Unique Constraint를 달아버리는 문제 때문에 `@ManyToMany` 데코레이터로 변경합니다.