### PR TITLE
WISH-386 migration: ProvisionalDonation, Deposit

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -42,6 +42,8 @@ import { Gift } from './entities/gift.entity';
 import { GiftogetherError } from './entities/error.entity';
 import { GiftogetherMiddleware } from './interfaces/giftogether.middleware';
 import { DepositModule } from './features/deposit/deposit.module';
+import { Deposit } from './features/deposit/domain/entities/deposit.entity';
+import { ProvisionalDonation } from './features/deposit/domain/entities/provisional-donation.entity';
 @Module({
   imports: [
     ScheduleModule.forRoot(),
@@ -76,6 +78,8 @@ import { DepositModule } from './features/deposit/deposit.module';
         Account,
         Gift,
         GiftogetherError,
+        Deposit,
+        ProvisionalDonation,
       ],
       ssl: {
         ca: readFileSync('global-bundle.pem'),

--- a/src/enums/error-code.enum.ts
+++ b/src/enums/error-code.enum.ts
@@ -77,4 +77,7 @@ export enum ErrorCode {
   // Deposits
   DepositUnmatched = '1500',
   DepositPartiallyMatched = '1501',
+
+  // Generic
+  InvalidStatusChange = '1600',
 }

--- a/src/enums/error-message.enum.ts
+++ b/src/enums/error-message.enum.ts
@@ -75,4 +75,7 @@ export enum ErrorMsg {
   // Deposits
   DepositUnmatched = '입금내역이 어느 후원과도 매칭되지 않습니다.',
   DepositPartiallyMatched = '입금내역과 후원금액이 서로 일치하지 않습니다.',
+
+  // Generic
+  InvalidStatusChange = '유효하지 않은 상태 변화입니다.',
 }

--- a/src/enums/provisional-donation-status.enum.ts
+++ b/src/enums/provisional-donation-status.enum.ts
@@ -2,4 +2,5 @@ export enum ProvisionalDonationStatus {
   Pending = 'Pending',
   Approved = 'Approved',
   Rejected = 'Rejected',
+  Refunded = 'Refunded',
 }

--- a/src/features/deposit/commands/match-deposit.usecase.ts
+++ b/src/features/deposit/commands/match-deposit.usecase.ts
@@ -1,27 +1,34 @@
 import { Injectable } from '@nestjs/common';
-import { InMemoryProvisionalDonationRepository } from '../infrastructure/repositories/in-memory-provisional-donation.repository';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { DepositMatchedEvent } from '../domain/events/deposit-matched.event';
 import { DepositUnmatchedEvent } from '../domain/events/deposit-unmatched.event';
 import { Deposit } from '../domain/entities/deposit.entity';
 import { GiftogetherExceptions } from '../../../filters/giftogether-exception';
-import { DepositStatus } from '../../../enums/deposit-status.enum';
 import { ProvisionalDonation } from '../domain/entities/provisional-donation.entity';
 import { DepositPartiallyMatchedEvent } from '../domain/events/deposit-partially-matched.event';
+import { FindProvDonationsBySenderSigUseCase } from '../queries/find-provisional-donations-by-sender-sig.usecase';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class MatchDepositUseCase {
   constructor(
+    @InjectRepository(Deposit)
+    private readonly depositRepo: Repository<Deposit>,
+
+    @InjectRepository(ProvisionalDonation)
+    private readonly provDonRepo: Repository<ProvisionalDonation>,
+
     private readonly eventEmitter: EventEmitter2,
+
     private readonly g2gException: GiftogetherExceptions,
-    private readonly findDonationsBySenderSig: FindDonationsBySenderSigUseCase,
-    private readonly increaseFundSum: IncreaseFundSumUseCase,
-    private readonly createDonation: CreateDonationUseCase,
+
+    private readonly findDonationsBySenderSig: FindProvDonationsBySenderSigUseCase,
   ) {}
 
-  execute(deposit: Deposit): void {
+  async execute(deposit: Deposit): Promise<void> {
     const donations: ProvisionalDonation[] =
-      this.findDonationsBySenderSig.execute(deposit.senderSig);
+      await this.findDonationsBySenderSig.execute(deposit.senderSig);
 
     if (donations.length === 0) {
       /**
@@ -32,7 +39,9 @@ export class MatchDepositUseCase {
        *  - 입금 내역을 '고아 상태'로 표시합니다.
        *  - 관리자는 해당 건에 대해 확인 및 조치를 취해야 합니다.
        */
-      deposit.status = DepositStatus.Orphan;
+      deposit.orphan(this.g2gException);
+      this.depositRepo.save(deposit);
+
       this.eventEmitter.emit(
         'deposit.unmatched',
         new DepositUnmatchedEvent(deposit),
@@ -55,7 +64,9 @@ export class MatchDepositUseCase {
        *  - 펀딩의 달성 금액이 업데이트 됩니다.
        *  - 후원자에게 후원이 정상적으로 처리되었음을 알리는 알림을 발송합니다.
        */
-      provDonation.approve();
+      provDonation.approve(this.g2gException);
+      this.provDonRepo.save(provDonation);
+
       this.eventEmitter.emit(
         'deposit.matched',
         new DepositMatchedEvent(deposit, provDonation),

--- a/src/features/deposit/commands/match-deposit.usecase.ts
+++ b/src/features/deposit/commands/match-deposit.usecase.ts
@@ -65,7 +65,7 @@ export class MatchDepositUseCase {
        *  - 후원자에게 후원이 정상적으로 처리되었음을 알리는 알림을 발송합니다.
        */
       provDonation.approve(this.g2gException);
-      this.provDonRepo.save(provDonation);
+      await this.provDonRepo.save(provDonation);
 
       this.eventEmitter.emit(
         'deposit.matched',

--- a/src/features/deposit/commands/upload-deposit.usecase.spec.ts
+++ b/src/features/deposit/commands/upload-deposit.usecase.spec.ts
@@ -3,7 +3,7 @@ import { Deposit } from '../domain/entities/deposit.entity';
 import { Repository } from 'typeorm';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken, TypeOrmModule } from '@nestjs/typeorm';
-import { dataSourceOptions } from 'src/tests/data-source-options';
+import { createDataSourceOptions } from 'src/tests/data-source-options';
 import { DepositDto } from '../dto/deposit.dto';
 
 const entities = [Deposit];
@@ -15,7 +15,7 @@ describe('UploadDepositUseCase', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [
-        TypeOrmModule.forRoot({ ...dataSourceOptions, entities: [Deposit] }),
+        TypeOrmModule.forRoot(createDataSourceOptions(entities)),
         TypeOrmModule.forFeature([...entities]),
       ],
       providers: [UploadDepositUseCase],

--- a/src/features/deposit/commands/upload-deposit.usecase.ts
+++ b/src/features/deposit/commands/upload-deposit.usecase.ts
@@ -1,13 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { Deposit } from '../domain/entities/deposit.entity';
-import { InMemoryDepositRepository } from '../infrastructure/repositories/in-memory-deposit.repository';
 import { DepositDto } from '../dto/deposit.dto';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
 
 @Injectable()
 export class UploadDepositUseCase {
-  constructor(private readonly depositRepository: InMemoryDepositRepository) {}
+  constructor(
+    @InjectRepository(Deposit)
+    private readonly depositRepository: Repository<Deposit>,
+  ) {}
 
-  execute(depositData: DepositDto): Deposit {
+  async execute(depositData: DepositDto): Promise<Deposit> {
     const deposit = Deposit.create(
       depositData.senderSig,
       depositData.receiver,
@@ -18,7 +22,7 @@ export class UploadDepositUseCase {
       depositData.withdrawalAccount,
     );
 
-    this.depositRepository.save(deposit);
+    await this.depositRepository.save(deposit);
 
     return deposit;
   }

--- a/src/features/deposit/commands/upload-deposit.usecase.ts
+++ b/src/features/deposit/commands/upload-deposit.usecase.ts
@@ -8,15 +8,15 @@ export class UploadDepositUseCase {
   constructor(private readonly depositRepository: InMemoryDepositRepository) {}
 
   execute(depositData: DepositDto): Deposit {
-    const deposit = Deposit.create({
-      sender: depositData.sender,
-      receiver: depositData.receiver,
-      amount: depositData.amount,
-      transferDate: depositData.transferDate,
-      depositBank: depositData.depositBank,
-      depositAccount: depositData.depositAccount,
-      withdrawalAccount: depositData.withdrawalAccount,
-    });
+    const deposit = Deposit.create(
+      depositData.senderSig,
+      depositData.receiver,
+      depositData.amount,
+      depositData.transferDate,
+      depositData.depositBank,
+      depositData.depositAccount,
+      depositData.withdrawalAccount,
+    );
 
     this.depositRepository.save(deposit);
 

--- a/src/features/deposit/deposit.module.ts
+++ b/src/features/deposit/deposit.module.ts
@@ -8,19 +8,25 @@ import { InMemoryDepositRepository } from './infrastructure/repositories/in-memo
 import { InMemoryProvisionalDonationRepository } from './infrastructure/repositories/in-memory-provisional-donation.repository';
 import { GiftogetherExceptions } from '../../filters/giftogether-exception';
 import { DepositEventHandler } from './domain/events/deposit-event.handler';
-import { InMemoryDonationRepository } from '../donation/infrastructure/repositories/in-memory-donation.repository';
-import { FundingRepository } from '../funding/infrastructure/repositories/funding.repository';
-import { NotificationService } from '../notification/notification.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Funding } from 'src/entities/funding.entity';
 import { Notification } from 'src/entities/notification.entity';
 import { User } from 'src/entities/user.entity';
 import { Donation } from 'src/entities/donation.entity';
+import { Deposit } from './domain/entities/deposit.entity';
+import { ProvisionalDonation } from './domain/entities/provisional-donation.entity';
 
 @Module({
   imports: [
     EventEmitterModule.forRoot(),
-    TypeOrmModule.forFeature([Funding, Notification, User, Donation]),
+    TypeOrmModule.forFeature([
+      Funding,
+      Notification,
+      User,
+      Donation,
+      Deposit,
+      ProvisionalDonation,
+    ]),
   ],
   controllers: [DepositController],
   providers: [
@@ -31,9 +37,6 @@ import { Donation } from 'src/entities/donation.entity';
     InMemoryProvisionalDonationRepository,
     GiftogetherExceptions,
     DepositEventHandler,
-    InMemoryDonationRepository,
-    FundingRepository,
-    NotificationService,
   ],
 })
 export class DepositModule {}

--- a/src/features/deposit/deposit.module.ts
+++ b/src/features/deposit/deposit.module.ts
@@ -15,6 +15,10 @@ import { User } from 'src/entities/user.entity';
 import { Donation } from 'src/entities/donation.entity';
 import { Deposit } from './domain/entities/deposit.entity';
 import { ProvisionalDonation } from './domain/entities/provisional-donation.entity';
+import { FindProvDonationsBySenderSigUseCase } from './queries/find-provisional-donations-by-sender-sig.usecase';
+import { CreateDonationUseCase } from '../donation/commands/create-donation.usecase';
+import { IncreaseFundSumUseCase } from '../funding/commands/increase-fundsum.usecase';
+import { NotificationService } from '../notification/notification.service';
 
 @Module({
   imports: [
@@ -37,6 +41,10 @@ import { ProvisionalDonation } from './domain/entities/provisional-donation.enti
     InMemoryProvisionalDonationRepository,
     GiftogetherExceptions,
     DepositEventHandler,
+    FindProvDonationsBySenderSigUseCase,
+    CreateDonationUseCase,
+    IncreaseFundSumUseCase,
+    NotificationService,
   ],
 })
 export class DepositModule {}

--- a/src/features/deposit/deposit.service.ts
+++ b/src/features/deposit/deposit.service.ts
@@ -12,7 +12,8 @@ export class DepositService {
   ) {}
 
   async uploadDeposit(depositData: DepositDto): Promise<DepositDto> {
-    const deposit: Deposit = this.uploadDepositUseCase.execute(depositData);
+    const deposit: Deposit =
+      await this.uploadDepositUseCase.execute(depositData);
 
     this.matchDepositUseCase.execute(deposit);
 

--- a/src/features/deposit/domain/entities/deposit.entity.ts
+++ b/src/features/deposit/domain/entities/deposit.entity.ts
@@ -17,27 +17,27 @@ export class Deposit {
   @PrimaryGeneratedColumn()
   readonly depositId: number;
 
-  @Column('string')
+  @Column('varchar')
   readonly senderSig: string; // 보내는분, '홍길동-1234'
 
-  @Column('string')
+  @Column('varchar')
   readonly receiver: string; // 받는분
 
   @IsInt()
   @Min(0)
-  @Column('number')
+  @Column('int')
   readonly amount: number;
 
   @Column('date')
   readonly transferDate: Date;
 
-  @Column('string')
+  @Column('varchar')
   readonly depositBank: string; // 이체은행
 
-  @Column('string')
+  @Column('varchar')
   readonly depositAccount: string; // 이체계좌번호
 
-  @Column('string')
+  @Column('varchar')
   readonly withdrawalAccount: string; // 환불계좌번호
 
   @Column({

--- a/src/features/deposit/domain/entities/deposit.entity.ts
+++ b/src/features/deposit/domain/entities/deposit.entity.ts
@@ -7,6 +7,7 @@ import {
 } from 'typeorm';
 import { DepositStatus } from '../../../../enums/deposit-status.enum';
 import { IsInt, Min } from 'class-validator';
+import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
 
 /**
  * 이체내역을 관리하는 엔티티 입니다.
@@ -48,6 +49,20 @@ export class Deposit {
 
   public get status(): DepositStatus {
     return this._status;
+  }
+
+  orphan(g2gException: GiftogetherExceptions) {
+    if (this._status !== DepositStatus.Unmatched) {
+      throw g2gException.InvalidStatusChange;
+    }
+    this._status = DepositStatus.Orphan;
+  }
+
+  matched(g2gException: GiftogetherExceptions) {
+    if (this._status !== DepositStatus.Unmatched) {
+      throw g2gException.InvalidStatusChange;
+    }
+    this._status = DepositStatus.Matched;
   }
 
   @CreateDateColumn()

--- a/src/features/deposit/domain/entities/deposit.entity.ts
+++ b/src/features/deposit/domain/entities/deposit.entity.ts
@@ -1,45 +1,86 @@
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { DepositStatus } from '../../../../enums/deposit-status.enum';
+import { IsInt, Min } from 'class-validator';
 
 /**
- * TODO - 현재 PoC를 위한 엔티티입니다. `@Entity` 데코레이터를 나중에 등록해야 합니다.
+ * 이체내역을 관리하는 엔티티 입니다.
  */
+@Entity()
 export class Deposit {
-  private _status: DepositStatus = DepositStatus.Unmatched;
+  @PrimaryGeneratedColumn()
+  readonly depositId: number;
 
-  get status(): DepositStatus {
+  @Column('string')
+  readonly senderSig: string; // 보내는분, '홍길동-1234'
+
+  @Column('string')
+  readonly receiver: string; // 받는분
+
+  @IsInt()
+  @Min(0)
+  @Column('number')
+  readonly amount: number;
+
+  @Column('date')
+  readonly transferDate: Date;
+
+  @Column('string')
+  readonly depositBank: string; // 이체은행
+
+  @Column('string')
+  readonly depositAccount: string; // 이체계좌번호
+
+  @Column('string')
+  readonly withdrawalAccount: string; // 환불계좌번호
+
+  @Column({
+    type: 'enum',
+    enum: DepositStatus,
+    name: 'status',
+  })
+  private _status: DepositStatus;
+
+  public get status(): DepositStatus {
     return this._status;
   }
 
-  set status(value: DepositStatus) {
-    this._status = value;
+  @CreateDateColumn()
+  regAt?: Date;
+
+  @DeleteDateColumn()
+  delAt?: Date;
+
+  protected constructor(
+    args: Partial<Deposit>,
+    status = DepositStatus.Unmatched,
+  ) {
+    Object.assign(this, args);
+    this._status = status;
   }
 
-  constructor(
-    public readonly senderSig: string, // "홍길동-1234"
-    public readonly receiver: string,
-    public readonly amount: number,
-    public readonly transferDate: Date,
-    public readonly depositBank: string,
-    public readonly depositAccount: string,
-    public readonly withdrawalAccount: string,
-  ) {}
-  static create(data: {
-    sender: string;
-    receiver: string;
-    amount: number;
-    transferDate: Date;
-    depositBank: string;
-    depositAccount: string;
-    withdrawalAccount: string;
-  }): Deposit {
-    return new Deposit(
-      data.sender,
-      data.receiver,
-      data.amount,
-      data.transferDate,
-      data.depositBank,
-      data.depositAccount,
-      data.withdrawalAccount,
-    );
+  static create(
+    senderSig: string,
+    receiver: string,
+    amount: number,
+    transferDate: Date,
+    depositBank: string,
+    depositAccount: string,
+    withdrawalAccount: string,
+  ): Deposit {
+    return new Deposit({
+      senderSig,
+      receiver,
+      amount,
+      transferDate,
+      depositBank,
+      depositAccount,
+      withdrawalAccount,
+    });
   }
 }

--- a/src/features/deposit/domain/entities/provisional-donation.entity.ts
+++ b/src/features/deposit/domain/entities/provisional-donation.entity.ts
@@ -22,22 +22,22 @@ export class ProvisionalDonation {
   @PrimaryGeneratedColumn()
   readonly provDonId: number;
 
-  @Column('string')
+  @Column('varchar')
   readonly senderSig: string; // '홍길동-1234'
 
-  @ManyToOne(() => User)
+  @ManyToOne(() => User, { onDelete: 'SET NULL' })
   @JoinColumn({
     name: 'senderUserId',
-    referencedColumnName: 'senderUserId',
+    referencedColumnName: 'userId',
   })
   readonly senderUser: User;
 
   @IsInt()
   @Min(0)
-  @Column('number')
+  @Column('int')
   readonly amount: number;
 
-  @ManyToOne(() => Funding)
+  @ManyToOne(() => Funding, { onDelete: 'SET NULL' })
   @JoinColumn({
     name: 'fundId',
     referencedColumnName: 'fundId',

--- a/src/features/deposit/domain/events/deposit-event.handler.spec.ts
+++ b/src/features/deposit/domain/events/deposit-event.handler.spec.ts
@@ -57,6 +57,7 @@ describe('DepositEventHandler', () => {
   let mockFunding: Funding;
   let createDonation: CreateDonationUseCase;
   let increaseFundSum: IncreaseFundSumUseCase;
+  let g2gException: GiftogetherExceptions;
 
   beforeEach(async () => {
     // TODO - move test module options into nice place
@@ -93,6 +94,7 @@ describe('DepositEventHandler', () => {
     notificationService = module.get(NotificationService);
     createDonation = module.get(CreateDonationUseCase);
     increaseFundSum = module.get(IncreaseFundSumUseCase);
+    g2gException = module.get(GiftogetherExceptions);
 
     // TODO - call mock factory
     fundingOwner = {
@@ -161,7 +163,7 @@ describe('DepositEventHandler', () => {
   });
 
   it('should handle deposit.matched event', async () => {
-    const deposit = new Deposit(
+    const deposit = Deposit.create(
       'sender',
       'receiver',
       1000,
@@ -171,8 +173,8 @@ describe('DepositEventHandler', () => {
       'withdrawalAccount',
     );
 
-    const provisionalDonation = new ProvisionalDonation(
-      '1',
+    const provisionalDonation = ProvisionalDonation.create(
+      g2gException,
       matchedDonor.userName + '-1234',
       matchedDonor,
       1000,

--- a/src/features/deposit/domain/events/deposit-event.handler.spec.ts
+++ b/src/features/deposit/domain/events/deposit-event.handler.spec.ts
@@ -2,8 +2,6 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { DepositEventHandler } from './deposit-event.handler';
 import { DepositMatchedEvent } from './deposit-matched.event';
 import { NotificationService } from 'src/features/notification/notification.service';
-import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
 import { User } from 'src/entities/user.entity';
 import { Funding } from 'src/entities/funding.entity';
 import { Donation } from 'src/entities/donation.entity';
@@ -22,8 +20,7 @@ import { Gift } from 'src/entities/gift.entity';
 import { CreateDonationUseCase } from 'src/features/donation/commands/create-donation.usecase';
 import { IncreaseFundSumUseCase } from 'src/features/funding/commands/increase-fundsum.usecase';
 import { GetDonationsByFundingUseCase } from 'src/features/donation/queries/get-donations-by-funding.usecase';
-import { Provider } from '@nestjs/common';
-import { createMockRepository } from '../../../../tests/create-mock-repository';
+import { createMockProvider } from '../../../../tests/create-mock-repository';
 
 const entities = [
   User,
@@ -60,7 +57,6 @@ describe('DepositEventHandler', () => {
   let g2gException: GiftogetherExceptions;
 
   beforeEach(async () => {
-    // TODO - move test module options into nice place
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DepositEventHandler,
@@ -69,24 +65,7 @@ describe('DepositEventHandler', () => {
         CreateDonationUseCase,
         IncreaseFundSumUseCase,
         GetDonationsByFundingUseCase,
-        /**
-         * 아래 프로바이더들은 Repository<Entity>를 모킹하기 위해
-         * 사용됩니다. 즉, 단위테스트를 위해 실제 RDS에 데이터를 저장하는
-         * 것이 아닌, MockRepository에 호출만 합니다.
-         *
-         * 만약 실제로 데이터를 넣고 그 결과를 재가공해야 할 필요가 있다면
-         * 아래 두가지 방법 중 하나를 사용할 수 있습니다:
-         *
-         * 1. TypeOrmModule을 `imports:`에 추가한다. 테스트 DB에 직접
-         *    데이터를 CRUD한다.
-         * 2. 사용하고자 하는 메서드만 In Memory에 조작을 가한다.
-         */
-        ...entities.map(
-          (e): Provider => ({
-            provide: getRepositoryToken(e),
-            useValue: createMockRepository(Repository<typeof e>),
-          }),
-        ),
+        ...entities.map(createMockProvider),
       ],
     }).compile();
 

--- a/src/features/deposit/dto/deposit.dto.ts
+++ b/src/features/deposit/dto/deposit.dto.ts
@@ -1,6 +1,6 @@
 export class DepositDto {
   constructor(
-    public readonly sender: string,
+    public readonly senderSig: string,
     public readonly receiver: string,
     public readonly amount: number,
     public readonly transferDate: Date,

--- a/src/features/deposit/queries/find-provisional-donations-by-sender-sig.usecase.ts
+++ b/src/features/deposit/queries/find-provisional-donations-by-sender-sig.usecase.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ProvisionalDonation } from '../domain/entities/provisional-donation.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class FindProvDonationsBySenderSigUseCase {
+  constructor(
+    @InjectRepository(ProvisionalDonation)
+    private readonly provDonRepo: Repository<ProvisionalDonation>,
+  ) {}
+
+  async execute(senderSig: string): Promise<ProvisionalDonation[]> {
+    const provDonations = this.provDonRepo.find({ where: { senderSig } });
+
+    return provDonations;
+  }
+}

--- a/src/features/donation/donation.service.ts
+++ b/src/features/donation/donation.service.ts
@@ -137,13 +137,7 @@ export class DonationService {
     const donAmnt = createDonationDto.donAmnt;
     const updateFunding = await this.updateFundingSum(funding, donAmnt);
 
-    const donation = new Donation();
-    donation.user = user;
-    donation.funding = updateFunding;
-
-    const orderId = require('order-id')('key').generate();
-    donation.orderId = orderId;
-    donation.donAmnt = donAmnt;
+    const donation = Donation.create(funding, user, donAmnt, this.g2gException);
 
     const savedDonation = await this.donationRepo.save(donation);
 

--- a/src/features/funding/funding.module.ts
+++ b/src/features/funding/funding.module.ts
@@ -21,6 +21,7 @@ import { AuthModule } from '../auth/auth.module';
 import { ImageService } from '../image/image.service';
 import { S3Service } from '../image/s3.service';
 import { ImageInstanceManager } from '../image/image-instance-manager';
+import { IncreaseFundSumUseCase } from './commands/increase-fundsum.usecase';
 
 @Module({
   imports: [
@@ -49,6 +50,7 @@ import { ImageInstanceManager } from '../image/image-instance-manager';
     ImageService,
     S3Service,
     ImageInstanceManager,
+    IncreaseFundSumUseCase,
   ],
   exports: [FundingService],
 })

--- a/src/features/funding/funding.module.ts
+++ b/src/features/funding/funding.module.ts
@@ -21,7 +21,6 @@ import { AuthModule } from '../auth/auth.module';
 import { ImageService } from '../image/image.service';
 import { S3Service } from '../image/s3.service';
 import { ImageInstanceManager } from '../image/image-instance-manager';
-import { FundingRepository } from './infrastructure/repositories/funding.repository';
 
 @Module({
   imports: [
@@ -50,7 +49,6 @@ import { FundingRepository } from './infrastructure/repositories/funding.reposit
     ImageService,
     S3Service,
     ImageInstanceManager,
-    FundingRepository,
   ],
   exports: [FundingService],
 })

--- a/src/filters/giftogether-exception.ts
+++ b/src/filters/giftogether-exception.ts
@@ -294,4 +294,12 @@ export class GiftogetherExceptions {
     ErrorCode.DepositPartiallyMatched,
     HttpStatus.BAD_REQUEST,
   );
+
+  // Generic
+
+  InvalidStatusChange = new GiftogetherException(
+    ErrorMsg.InvalidStatusChange,
+    ErrorCode.InvalidStatusChange,
+    HttpStatus.BAD_REQUEST,
+  );
 }

--- a/src/tests/create-mock-repository.ts
+++ b/src/tests/create-mock-repository.ts
@@ -1,5 +1,8 @@
-import { SelectQueryBuilder } from 'typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
 import { createMock } from './create-mock';
+import { EntityClassOrSchema } from '@nestjs/typeorm/dist/interfaces/entity-class-or-schema.type';
+import { Provider } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
 
 type MockRepository<T> = jest.Mocked<T> & {
   createQueryBuilder: jest.Mocked<SelectQueryBuilder<T>>;
@@ -22,6 +25,19 @@ function createMockSelectQueryBuilder<T>(): jest.Mocked<SelectQueryBuilder<T>> {
   } as unknown as jest.Mocked<SelectQueryBuilder<T>>;
 }
 
+/**
+ * 아래 함수는 Repository<Entity>를 모킹하기 위해
+ * 사용됩니다. 즉, 단위테스트를 위해 실제 RDS에 데이터를 저장하는
+ * 것이 아닌, MockRepository에 호출만 합니다.
+ *
+ * 만약 실제로 데이터를 넣고 그 결과를 재가공해야 할 필요가 있다면
+ * 아래 두가지 방법 중 하나를 사용할 수 있습니다:
+ *
+ * 1. TypeOrmModule을 `imports:`에 추가한다. 테스트 DB에 직접
+ *    데이터를 CRUD한다. (src/tests/data-source-options.ts 참조)
+ * 2. 사용하고자 하는 메서드만 따로 구현한 MockRepository를 구현,
+ *    `useValue:` 자리에 따로 작성한다.
+ */
 export function createMockRepository<T>(
   cls: new (...args: any[]) => T,
 ): MockRepository<T> {
@@ -30,3 +46,8 @@ export function createMockRepository<T>(
 
   return mock;
 }
+
+export const createMockProvider = (entity: EntityClassOrSchema): Provider => ({
+  provide: getRepositoryToken(entity),
+  useValue: createMockRepository(Repository<typeof entity>),
+});

--- a/src/tests/data-source-options.ts
+++ b/src/tests/data-source-options.ts
@@ -1,3 +1,4 @@
+import { EntityClassOrSchema } from '@nestjs/typeorm/dist/interfaces/entity-class-or-schema.type';
 import { readFileSync } from 'fs';
 import { DataSourceOptions } from 'typeorm';
 
@@ -6,12 +7,12 @@ import { DataSourceOptions } from 'typeorm';
  *
  * ```
  * imports: [
- *   TypeOrmModule.forRoot({ ...dataSourceOptions, autoLoadEntities: true }),
+ *   TypeOrmModule.forRoot({ ...dataSourceOptions, entities: [...entities] }),
  *   TypeOrmModule.forFeature(entities),
  * ],
  * ```
  */
-export const dataSourceOptions: DataSourceOptions = {
+const dataSourceOptions: DataSourceOptions = {
   type: 'postgres',
   host: process.env.DB_HOST,
   port: parseInt(process.env.DB_PORT) || 5432,
@@ -30,3 +31,9 @@ export const dataSourceOptions: DataSourceOptions = {
     },
   },
 };
+
+export function createDataSourceOptions(
+  entities: EntityClassOrSchema[],
+): DataSourceOptions {
+  return { ...dataSourceOptions, entities };
+}

--- a/src/tests/data-source-options.ts
+++ b/src/tests/data-source-options.ts
@@ -12,7 +12,7 @@ import { DataSourceOptions } from 'typeorm';
  * ],
  * ```
  */
-const dataSourceOptions: DataSourceOptions = {
+export const dataSourceOptions: DataSourceOptions = {
   type: 'postgres',
   host: process.env.DB_HOST,
   port: parseInt(process.env.DB_PORT) || 5432,


### PR DESCRIPTION
### 주요 변경 사항
이번 PR에서는 기부금 매칭 및 관리 로직의 주요 업데이트가 이루어졌습니다. 다음의 주요 기능 및 코드 변경 사항이 포함됩니다:

1. **Deposit 및 ProvisionalDonation 엔티티 리팩토링**  
   - TypeORM 엔티티로 등록하여 데이터베이스와 연동 가능하도록 수정했습니다.  
   - 각 엔티티에 상태 전이 메서드 (`approve`, `reject`, `refund` 등)를 추가하여 상태 관리 로직을 강화했습니다.  
   - 상태 전이 로직에 예외 처리를 추가하여 잘못된 상태 전이를 방지했습니다.

2. **새로운 유스케이스 추가**  
   - `FindProvDonationsBySenderSigUseCase`를 구현하여 `senderSig` 기반으로 ProvisionalDonation을 검색할 수 있도록 했습니다.  
   - 이 유스케이스는 `MatchDepositUseCase`에서 사용됩니다.

3. **기능 확장 및 코드 리팩토링**  
   - `MatchDepositUseCase` 및 `UploadDepositUseCase`에서 기존의 메모리 기반 레포지토리를 제거하고, TypeORM 기반 레포지토리로 대체했습니다.  
   - `execute` 메서드가 비동기로 변경되어 데이터베이스 작업을 처리할 수 있도록 개선했습니다.  
   - `DepositDto`의 `sender` 필드를 `senderSig`로 변경했습니다.

4. **Error Code 및 Error Message 추가**  
   - 상태 전이와 관련된 새로운 에러 코드(`1600`) 및 메시지를 추가했습니다.

5. **기타**  
   - 기존 Donation 생성 로직을 `Donation.create` 팩토리 메서드로 통합했습니다.  
   - `FundingModule` 내에서 관련 유스케이스를 리팩토링하여 역할을 명확히 했습니다.

---

### 파일별 주요 변경 내용
#### **`app.module.ts`**
- 새로운 엔티티(`Deposit`, `ProvisionalDonation`)를 등록하여 TypeORM 모듈과 연동.

#### **`error-code.enum.ts` 및 `error-message.enum.ts`**
- 상태 전이와 관련된 에러 코드 및 메시지 추가.

#### **`provisional-donation-status.enum.ts`**
- 새로운 상태 `Refunded` 추가.

#### **`match-deposit.usecase.ts`**
- `senderSig` 기반으로 ProvisionalDonation을 검색하도록 변경.
- 상태 전이에 따라 데이터베이스에 저장하는 로직 추가.

#### **`deposit.entity.ts` 및 `provisional-donation.entity.ts`**
- TypeORM 데코레이터 추가 및 상태 전이 메서드 구현.

#### **`find-provisional-donations-by-sender-sig.usecase.ts`**
- `senderSig`로 ProvisionalDonation을 검색하는 새로운 유스케이스 구현.

---

### 기대 효과
1. **데이터 일관성 향상**  
   - 데이터베이스 기반으로 상태와 관계를 관리하여 시스템 안정성이 강화됩니다.
   
2. **확장성 증가**  
   - 엔티티 중심 설계로 새로운 상태나 로직 추가가 용이해졌습니다.
   
3. **유지보수성 개선**  
   - 상태 전이를 메서드로 캡슐화하여 코드 가독성과 유지보수성을 높였습니다.

---

### RDS Migration 결과

현재 test1 데이터베이스에만 마이그레이션이 완료가 되었습니다. 아래 추가된 두 테이블의 스키마를 첨부합니다:

**provisional_donation**

```
                                         table "public.provisional_donation"
     Name     |              Type              | Nullable |                          Default
--------------+--------------------------------+----------+-----------------------------------------------------------
 provDonId    | integer                        | "NO"     | nextval('"provisional_donation_provDonId_seq"'::regclass)
 senderSig    | character varying              | "NO"     |
 amount       | integer                        | "NO"     |
 status       | USER-DEFINED                   | "NO"     | 'Pending'::provisional_donation_status_enum
 regAt        | timestamp(6) without time zone | "NO"     | now()
 delAt        | timestamp(6) without time zone | "YES"    |
 senderUserId | integer                        | "YES"    |
 fundId       | integer                        | "YES"    |
Indexes:
  "PK_9bc8653ff50c559fa5bd59540e0" PRIMARY_KEY, UNIQUE, btree (provDonId)
Foreign-key constraints:
  "FK_1a3624edf4a4bf57ad59d035ae5" FOREIGN KEY (senderUserId) REFERENCES user(userId) ON UPDATE NO ACTION ON DELETE SET NULL
  "FK_5ac622a2dfddc91a5519629da8b" FOREIGN KEY (fundId) REFERENCES funding(fundId) ON UPDATE NO ACTION ON DELETE SET NULL
```

**deposit**

```
                                            table "public.deposit"
       Name        |              Type              | Nullable |                   Default
-------------------+--------------------------------+----------+----------------------------------------------
 depositId         | integer                        | "NO"     | nextval('"deposit_depositId_seq"'::regclass)
 senderSig         | character varying              | "NO"     |
 receiver          | character varying              | "NO"     |
 amount            | integer                        | "NO"     |
 transferDate      | date                           | "NO"     |
 depositBank       | character varying              | "NO"     |
 depositAccount    | character varying              | "NO"     |
 withdrawalAccount | character varying              | "NO"     |
 status            | USER-DEFINED                   | "NO"     |
 regAt             | timestamp(6) without time zone | "NO"     | now()
 delAt             | timestamp(6) without time zone | "YES"    |
Indexes:
  "PK_5fbf4ce843813af12002f62b212" PRIMARY_KEY, UNIQUE, btree (depositId)
```

---

### 추후 진행상황

- [x] 모든 변경 사항 단위 테스트 및 통합 테스트 진행  
- [ ] 주요 상태 전이에 대한 예외 처리 케이스를 추가로 테스트
- [x] 개발 환경에서 데이터베이스 연동 여부 확인
- [x] [wishlist_funding_dbdiagram](https://github.com/ChoiWheatley/wishlist_funding_dbdiagram) 에 두 테이블 스키마 추가
