### PR TITLE
WISH-383 DonationPartiallyMatched Handler

### DIFF
--- a/src/enums/noti-type.enum.ts
+++ b/src/enums/noti-type.enum.ts
@@ -9,6 +9,7 @@ export enum NotiType {
   CheckGratitude = 'CheckGratitude', // 내가 후원한 펀딩 감사인사 확인
   NewComment = 'NewComment', // 새로운 댓글
   DonationSuccess = 'DonationSuccess', // 후원이 성공적으로 이루어졌음
+  DonationPartiallyMatched = 'DonationPartiallyMatched', // 후원이 금액이 안맞음
   DepositUnmatched = 'DepositUnmatched', // 이체내역이 어디에도 매치하지 않는 경우
 }
 

--- a/src/features/deposit/commands/match-deposit.usecase.spec.ts
+++ b/src/features/deposit/commands/match-deposit.usecase.spec.ts
@@ -14,7 +14,6 @@ import { FundTheme } from 'src/enums/fund-theme.enum';
 import { ProvisionalDonationStatus } from 'src/enums/provisional-donation-status.enum';
 import { Repository } from 'typeorm';
 import { getRepositoryToken, TypeOrmModule } from '@nestjs/typeorm';
-import { FindProvDonationsBySenderSigUseCase } from '../queries/find-provisional-donations-by-sender-sig.usecase';
 import { createDataSourceOptions } from 'src/tests/data-source-options';
 import { Account } from 'src/entities/account.entity';
 import { Comment } from 'src/entities/comment.entity';
@@ -52,11 +51,7 @@ describe('MatchDepositUseCase', () => {
         TypeOrmModule.forFeature(entities),
       ],
       controllers: [],
-      providers: [
-        GiftogetherExceptions,
-        MatchDepositUseCase,
-        FindProvDonationsBySenderSigUseCase,
-      ],
+      providers: [GiftogetherExceptions, MatchDepositUseCase],
     }).compile();
 
     matchDepositUseCase = module.get(MatchDepositUseCase);

--- a/src/features/deposit/deposit.module.ts
+++ b/src/features/deposit/deposit.module.ts
@@ -15,7 +15,6 @@ import { User } from 'src/entities/user.entity';
 import { Donation } from 'src/entities/donation.entity';
 import { Deposit } from './domain/entities/deposit.entity';
 import { ProvisionalDonation } from './domain/entities/provisional-donation.entity';
-import { FindProvDonationsBySenderSigUseCase } from './queries/find-provisional-donations-by-sender-sig.usecase';
 import { CreateDonationUseCase } from '../donation/commands/create-donation.usecase';
 import { IncreaseFundSumUseCase } from '../funding/commands/increase-fundsum.usecase';
 import { NotificationService } from '../notification/notification.service';
@@ -43,7 +42,6 @@ import { FindAllAdminsUseCase } from '../admin/queries/find-all-admins.usecase';
     InMemoryProvisionalDonationRepository,
     GiftogetherExceptions,
     DepositEventHandler,
-    FindProvDonationsBySenderSigUseCase,
     CreateDonationUseCase,
     IncreaseFundSumUseCase,
     DecreaseFundSumUseCase,

--- a/src/features/deposit/domain/events/deposit-event.handler.ts
+++ b/src/features/deposit/domain/events/deposit-event.handler.ts
@@ -74,8 +74,21 @@ export class DepositEventHandler {
     await this.notiService.createNoti(createNotificationDtoForReceiver);
   }
 
+  /**
+   * - 조건: 보내는 분은 일치하지만 이체 금액이 다른 경우 → 부분 매칭
+   *
+   * 1. 예비 후원의 상태를 ‘반려’로 변경합니다.
+   * 2. 시스템은 후원자에게 반려 사유를 포함한 알림을 발송합니다.
+   * 3. 시스템은 관리자에게 부분매칭이 된 예비후원이 발생함 알림을 발송합니다.
+   * 4. 관리자는 해당 건에 대해서 환불, 혹은 삭제 조치를 진행해야 합니다.
+   */
   @OnEvent('deposit.partiallyMatched')
-  handleDepositPartiallyMatched(event: DepositPartiallyMatchedEvent) {}
+  handleDepositPartiallyMatched(event: DepositPartiallyMatchedEvent) {
+    const { deposit, provDon } = event;
+
+    // 1
+    provDon.reject(this.g2gException);
+  }
 
   /**
    * 1. 입금 내역을 ‘고아 상태’로 표시합니다.

--- a/src/features/deposit/domain/events/deposit-partially-matched.event.ts
+++ b/src/features/deposit/domain/events/deposit-partially-matched.event.ts
@@ -1,5 +1,9 @@
 import { Deposit } from 'src/features/deposit/domain/entities/deposit.entity';
+import { ProvisionalDonation } from '../entities/provisional-donation.entity';
 
 export class DepositPartiallyMatchedEvent {
-  constructor(public readonly deposit: Deposit) {}
+  constructor(
+    public readonly deposit: Deposit,
+    public readonly provDon: ProvisionalDonation,
+  ) {}
 }

--- a/src/features/deposit/queries/find-provisional-donations-by-sender-sig.usecase.ts
+++ b/src/features/deposit/queries/find-provisional-donations-by-sender-sig.usecase.ts
@@ -3,6 +3,9 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { ProvisionalDonation } from '../domain/entities/provisional-donation.entity';
 import { Repository } from 'typeorm';
 
+/**
+ * @deprecated 사유: 단순한 액티브 레코드는 TypeORM이 해결해주었다. 상대적으로 복잡한 query builder에만 유스케이스를 두는 것이 더 낫다.
+ */
 @Injectable()
 export class FindProvDonationsBySenderSigUseCase {
   constructor(


### PR DESCRIPTION
# PR 설명

## 변경 사항 요약
1. **새로운 알림 유형 추가**:
   - `DonationPartiallyMatched`: 입금 금액이 불일치할 경우의 알림 유형 추가.

2. **비효율적인 유스케이스 제거**:
   - `FindProvDonationsBySenderSigUseCase` 유스케이스가 제거되었습니다.
   - 단순한 레코드 조회는 TypeORM의 기본 기능을 사용하여 대체.

3. **비즈니스 로직 업데이트**:
   - 부분 매칭 로직 개선:
     - 매칭되지 않는 경우에도 알림을 통해 정확한 상태 전달.
     - 관리자에게 알림 발송 추가.
   - `DepositPartiallyMatchedEvent`에 `ProvisionalDonation` 데이터 포함.

4. **테스트 및 핸들러 추가**:
   - `DepositEventHandler`의 부분 매칭 이벤트 로직에 대한 테스트 케이스 추가.
   - 관리자 및 후원자 알림 검증.

## 주요 변경 파일
1. **`noti-type.enum.ts`**:
   - 새로운 알림 유형 `DonationPartiallyMatched` 추가.

2. **`match-deposit.usecase.ts`**:
   - `FindProvDonationsBySenderSigUseCase` 제거.
   - 비즈니스 로직 단순화 및 명확화.

3. **`deposit-event.handler.ts`**:
   - 부분 매칭 이벤트 핸들링 구현:
     - `ProvisionalDonation` 상태 반려.
     - 관리자와 후원자 알림 발송.

4. **`deposit-partially-matched.event.ts`**:
   - `DepositPartiallyMatchedEvent`에 `ProvisionalDonation` 추가.

5. **테스트 파일**:
   - `match-deposit.usecase.spec.ts`: 로직 변경 반영.
   - `deposit-event.handler.spec.ts`: 부분 매칭 이벤트 테스트 추가.

## 이유 및 효과
1. **불필요한 유스케이스 제거**:
   - 유지보수성 향상.
   - 코드 복잡도 감소.

2. **부분 매칭 로직 개선**:
   - 실사용자 경험 강화:
     - 후원자는 빠르게 상태를 파악 가능.
     - 관리자는 효율적으로 처리 가능.

3. **테스트 보강**:
   - 신규 로직 안정성 보장.
   - 경계 조건 및 예외 처리 강화.

## 기타 참고 사항
- **Deprecated 주석 추가**: `FindProvDonationsBySenderSigUseCase` 제거 이유를 주석으로 명시.
- **호환성 테스트 필요**: 추가된 알림 타입에 대해 알림 서비스의 레거시 호환성 점검 필요.