### PR TITLE
WISH-393-Image-URL-in-CommentDto

### DIFF
--- a/src/features/comment/comment.module.ts
+++ b/src/features/comment/comment.module.ts
@@ -6,13 +6,17 @@ import { Funding } from 'src/entities/funding.entity';
 import { User } from 'src/entities/user.entity';
 import { Comment } from 'src/entities/comment.entity';
 import { AuthModule } from '../auth/auth.module';
-import { JwtAuthGuard } from '../auth/guard/jwt-auth-guard';
 import { JwtService } from '@nestjs/jwt';
 import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
 import { ValidCheck } from 'src/util/valid-check';
+import { ImageModule } from '../image/image.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Funding, User, Comment]), AuthModule],
+  imports: [
+    TypeOrmModule.forFeature([Funding, User, Comment]),
+    AuthModule,
+    ImageModule,
+  ],
   controllers: [CommentController],
   providers: [CommentService, JwtService, GiftogetherExceptions, ValidCheck],
 })

--- a/src/features/comment/comment.service.ts
+++ b/src/features/comment/comment.service.ts
@@ -94,9 +94,10 @@ export class CommentService {
         { isDel: false },
       )
       .leftJoinAndSelect('comment.author', 'author')
-      .leftJoinAndSelect(
-        'image',
-        'authorImage',
+      .leftJoinAndMapOne(
+        'author.image', // map to property 'image' of 'author'
+        'image', // property name of 'author'
+        'authorImage', // alias of 'image' table
         `
         (author.defaultImgId IS NOT NULL AND authorImage.imgId = author.defaultImgId)
         OR

--- a/src/features/comment/comment.service.ts
+++ b/src/features/comment/comment.service.ts
@@ -141,9 +141,9 @@ export class CommentService {
 
     this.commentRepository.save(comment);
 
-    comment.author.image = await this.imageInstanceManager.getImages(
-      comment.author,
-    )[0];
+    comment.author.image = await this.imageInstanceManager
+      .getImages(comment.author)
+      .then((images) => images[0]);
     return convertToGetCommentDto(comment);
   }
 

--- a/src/features/comment/comment.service.ts
+++ b/src/features/comment/comment.service.ts
@@ -164,9 +164,9 @@ export class CommentService {
     comment.isDel = true;
     this.commentRepository.save(comment);
 
-    comment.author.image = await this.imageInstanceManager.getImages(
-      comment.author,
-    )[0];
+    comment.author.image = await this.imageInstanceManager
+      .getImages(comment.author)
+      .then((images) => images[0]);
     return convertToGetCommentDto(comment);
   }
 }

--- a/src/features/comment/comment.service.ts
+++ b/src/features/comment/comment.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
 import { Comment } from 'src/entities/comment.entity';

--- a/src/features/comment/comment.service.ts
+++ b/src/features/comment/comment.service.ts
@@ -108,8 +108,6 @@ export class CommentService {
       .where('funding.fundUuid = :fundUuid', { fundUuid })
       .orderBy('comment.regAt', 'DESC');
 
-    Logger.log(fundingQb.getSql());
-
     const funding = await fundingQb.getOne();
     if (!funding) {
       throw this.g2gException.FundingNotExists;

--- a/src/features/comment/comment.service.ts
+++ b/src/features/comment/comment.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
 import { Comment } from 'src/entities/comment.entity';
@@ -10,11 +10,21 @@ import { User } from 'src/entities/user.entity';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { GiftogetherExceptions } from 'src/filters/giftogether-exception';
 import { ValidCheck } from 'src/util/valid-check';
+import { ImageInstanceManager } from '../image/image-instance-manager';
+import { ImageType } from 'src/enums/image-type.enum';
 
 function convertToGetCommentDto(comment: Comment): GetCommentDto {
   const { comId, content, regAt, isMod, authorId, author } = comment;
   const authorName = author?.userName ?? 'ANONYMOUS';
-  return new GetCommentDto(comId, content, regAt, isMod, authorId, authorName);
+  return new GetCommentDto(
+    comId,
+    content,
+    regAt,
+    isMod,
+    authorId,
+    authorName,
+    author?.image?.imgUrl,
+  );
 }
 
 @Injectable()
@@ -26,6 +36,7 @@ export class CommentService {
     private eventEmitter: EventEmitter2,
     private readonly g2gException: GiftogetherExceptions,
     private readonly validCheck: ValidCheck,
+    private readonly imageInstanceManager: ImageInstanceManager,
   ) {}
 
   async create(
@@ -46,6 +57,9 @@ export class CommentService {
     if (!author) {
       throw this.g2gException.UserNotFound;
     }
+    author.image = await this.imageInstanceManager
+      .getImages(author)
+      .then((images) => images[0]);
 
     const newComment = new Comment({
       funding,
@@ -71,7 +85,7 @@ export class CommentService {
    * @returns Comment[]
    */
   async findMany(fundUuid: string): Promise<GetCommentDto[]> {
-    const funding = await this.fundingRepository
+    const fundingQb = this.fundingRepository
       .createQueryBuilder('funding')
       .leftJoinAndSelect(
         'funding.comments',
@@ -80,9 +94,22 @@ export class CommentService {
         { isDel: false },
       )
       .leftJoinAndSelect('comment.author', 'author')
+      .leftJoinAndSelect(
+        'image',
+        'authorImage',
+        `
+        (author.defaultImgId IS NOT NULL AND authorImage.imgId = author.defaultImgId)
+        OR
+        (author.defaultImgId IS NULL AND authorImage.subId = author.userId AND authorImage.imgType = :imgType)
+        `,
+        { imgType: ImageType.User },
+      )
       .where('funding.fundUuid = :fundUuid', { fundUuid })
-      .orderBy('comment.regAt', 'DESC')
-      .getOne();
+      .orderBy('comment.regAt', 'DESC');
+
+    Logger.log(fundingQb.getSql());
+
+    const funding = await fundingQb.getOne();
     if (!funding) {
       throw this.g2gException.FundingNotExists;
     }
@@ -113,6 +140,9 @@ export class CommentService {
 
     this.commentRepository.save(comment);
 
+    comment.author.image = await this.imageInstanceManager.getImages(
+      comment.author,
+    )[0];
     return convertToGetCommentDto(comment);
   }
 
@@ -133,6 +163,9 @@ export class CommentService {
     comment.isDel = true;
     this.commentRepository.save(comment);
 
+    comment.author.image = await this.imageInstanceManager.getImages(
+      comment.author,
+    )[0];
     return convertToGetCommentDto(comment);
   }
 }

--- a/src/features/comment/dto/get-comment.dto.ts
+++ b/src/features/comment/dto/get-comment.dto.ts
@@ -6,5 +6,6 @@ export class GetCommentDto {
     public isMod: boolean,
     public authorId: number,
     public authorName: string,
+    public authorImg: string,
   ) {}
 }


### PR DESCRIPTION
## 댓글 기능에 사용자 프로필 이미지 연동 및 이미지 처리 로직 추가

댓글 기능에서 사용자 프로필 이미지를 연동하고, 관련된 이미지 처리 로직을 추가했습니다. 이 변경으로 댓글 데이터에서 사용자 프로필 이미지 URL을 제공할 수 있으며, UI에서 이를 활용해 사용자 경험을 개선할 수 있습니다.

### 주요 변경 사항
1. **댓글 모듈 수정**
   - `ImageModule`을 `CommentModule`의 import에 추가했습니다.

2. **댓글 서비스 수정**
   - `ImageInstanceManager`를 의존성으로 주입하여 사용자 프로필 이미지를 처리.
   - 댓글 작성, 수정, 삭제 및 조회 시 `author.image` 필드에 사용자 프로필 이미지 정보를 추가.
   - `findMany` 메서드에서 QueryBuilder를 사용하여 사용자 이미지 데이터를 매핑.

3. **DTO 수정**
   - `GetCommentDto`에 `authorImg` 필드 추가.
   - 댓글 조회 시 사용자 프로필 이미지 URL 반환.

4. **QueryBuilder 로직 강화**
   - `author.image`를 동적으로 매핑하기 위한 조건 추가:
     - 기본 이미지(`defaultImgId`)가 설정된 경우 해당 이미지를 반환.
     - 기본 이미지가 없을 경우, 사용자 ID와 이미지 타입을 기준으로 이미지를 매핑.

### 테스트 및 검증
- 댓글 작성, 조회, 수정, 삭제 시 사용자 프로필 이미지가 올바르게 반환되는지 확인.
- QueryBuilder 로직을 통해 사용자 이미지 데이터가 정확히 매핑되는지 검증.
- 기존 기능이 변경 사항으로 인해 영향을 받지 않는지 확인.

### 관련 이슈
- [WISH-393](https://wishfund.atlassian.net/browse/WISH-393): 댓글에서 사용자 프로필 이미지 제공 필요
- [WISH-391](https://wishfund.atlassian.net/browse/WISH-391): ImageInstanceManager의 N+1 쿼리 문제를 해결할 실마리를 찾았다.

### 체크리스트
- [x] 기능 동작 확인
- [x] 유닛 테스트 추가 및 통과
- [x] SQL 로깅 확인
- [x] 기존 코드와의 호환성 검증

리뷰 부탁드립니다! 🙇‍♂️

[WISH-393]: https://wishfund.atlassian.net/browse/WISH-393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WISH-391]: https://wishfund.atlassian.net/browse/WISH-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ