### PR TITLE
Centralize Event Handlers 2안

### DIFF
--- a/src/tests/tests.module.ts
+++ b/src/tests/tests.module.ts
@@ -41,7 +41,7 @@ const customRedisProvider: Provider = {
     TypeOrmModule.forFeature(entities),
     ConfigModule.forRoot({
       isGlobal: true,
-      envFilePath: ['.env.test.local'],
+      envFilePath: ['.env'],
     }),
     EventModule,
     TokenModule,


### PR DESCRIPTION
이 버전은 ConfigModule을 `envFilePath: ['.env']`로 변경한 버전입니다. 이전 버전에서는 `.env.test.local`을 사용하였으나 환경변수 오버라이딩이 안돼 다른 이름의 환경변수 `TEST_REDIS_HOST`를 사용하면서 별 의미가 없어졌습니다.