### PR TITLE
WISH-440 Reset ProvDon When Matched Deposit Deletion Requested

### DIFF
--- a/src/features/deposit/deposit.e2e.spec.ts
+++ b/src/features/deposit/deposit.e2e.spec.ts
@@ -488,7 +488,7 @@ describe('Deposit API E2E Test', () => {
       expect(foundDeposit).toBeNull();
     });
 
-    it('should delete donation and decrease fundSum if matched', async () => {
+    it('should delete donation and decrease fundSum and reset to pending on provdon if matched', async () => {
       // Scenario: Create matched deposit, donation, and funding
       const funding = await createMockFundingWithRelations(
         {
@@ -496,11 +496,12 @@ describe('Deposit API E2E Test', () => {
           fundingRepo,
           depositRepo,
           donationRepo,
+          provDonRepo,
         },
         {
           fundUser: mockFundingOwner,
         },
-        { deposit: 1, donation: 1 },
+        { deposit: 1, donation: 1, provDonation: 1 },
       );
 
       const donation = funding.donations[0];
@@ -524,6 +525,12 @@ describe('Deposit API E2E Test', () => {
         where: { donId: donation.donId },
       });
       expect(foundDonation).toBeNull();
+
+      // Provisional Donation의 상태가 Pending이어야 합니다.
+      const foundProvDon = await provDonRepo.findOne({
+        where: { senderSig: deposit.senderSig },
+      });
+      expect(foundProvDon.status).toBe(ProvisionalDonationStatus.Pending);
     });
   });
 

--- a/src/tests/mock-factory.ts
+++ b/src/tests/mock-factory.ts
@@ -234,22 +234,21 @@ export const createMockFundingWithRelations = async (
       mockFunding.donations = donations;
       await delegate.fundingRepo.save(mockFunding);
     }
-  }
 
-  // Handle optional provisional donations
-  if (delegate.provDonRepo) {
-    await Promise.all(
-      Array(amount?.provDonation ?? 1)
-        .fill(null)
-        .map(() =>
-          delegate.provDonRepo.save(
+    // Handle optional provisional donations
+    if (delegate.provDonRepo) {
+      await delegate.provDonRepo.save(
+        Array(amount?.provDonation ?? 1)
+          .fill(null)
+          .map((_, index) =>
             createMockProvisionalDonation({
               funding: mockFunding,
               senderUser: mockUser,
+              senderSig: deposits[index].senderSig,
             }),
           ),
-        ),
-    );
+      );
+    }
   }
 
   return mockFunding;


### PR DESCRIPTION
#### 📝 변경 사항
이번 PR에서는 **후원 삭제 프로세스 개선 및 예비후원(Provisional Donation) 상태 관리**를 추가하였습니다.

1. **후원 삭제 시 예비후원 상태 초기화 추가**
   - 기존에는 후원 삭제 시 연관된 후원만 제거했으나, 이제는 예비후원의 상태를 초기화한 후 이체 내역을 삭제합니다.
   - `DepositDeleteSaga.handleMatchedDepositDeleteRequested()` 내에서 예비후원의 매치를 취소하는 로직을 추가하였으며, 실패 시 적절한 보상 조치(관리자 알림 발송)를 수행합니다.

2. **예비후원 매치 취소 실패 처리**
   - `cancelMatchProvDon.execute()` 호출 시 `InvalidStatus` 예외가 발생하면 관리자에게 알림을 보내도록 보상 조치를 추가했습니다.

3. **E2E 테스트 업데이트**
   - `Deposit API E2E Test`에서 후원 삭제 후 예비후원의 상태가 `Pending`으로 변경되는지를 검증하는 테스트 케이스를 추가했습니다.

4. **Mock 데이터 생성 개선**
   - 기존 `createMockFundingWithRelations()` 함수에서 `provisional donation`을 생성할 때, `senderSig` 값을 적절히 설정하도록 수정했습니다.

#### 📌 주요 변경 파일
- `src/event-handlers/deposit-delete.saga.ts`
- `src/features/deposit/deposit.e2e.spec.ts`
- `src/tests/mock-factory.ts`

#### ✅ 검토 포인트
- 예비후원의 상태를 `Pending`으로 초기화하는 방식이 적절한지
- `InvalidStatus` 예외 발생 시 관리자 알림 처리가 적절한지
- 새로운 E2E 테스트 케이스가 충분히 검증하는지

#### 🚀 기대 효과
- 후원 삭제 시 예비후원 데이터 정합성을 보장
- 예비후원 매치 취소 실패 시 적절한 보상 조치를 수행하여 안정성 확보
- 관련 테스트 케이스 추가로 인한 기능 보장 강화


#### ⚠️ 토론

Deposit을 두 번 삭제 시도합니다. 그 이유는 Donation 삭제 성공 이벤트 핸들러에서 한 번, ProvDon 리셋 성공 이벤트 핸들러에서 한 번. 하지만 결과적으로 Eventual Consistency를 만족시키니까, 내비두어야 할까요?

리뷰 부탁드립니다! 🙌