### PR TITLE
refactor: ImageInstanceManager#mapImage

### DIFF
--- a/src/features/funding/funding.service.ts
+++ b/src/features/funding/funding.service.ts
@@ -226,17 +226,8 @@ export class FundingService {
 
     queryBuilder.leftJoinAndSelect('funding.fundUser', 'u');
 
-    // 현재 Nested Entity에는 ImageInstanceManager#mapImage를 사용할 수 없다.
-    queryBuilder.leftJoinAndMapOne(
-      'u.image',
-      'image',
-      'ui',
-      `
-      (u.defaultImgId IS NOT NULL AND ui.imgId = u.defaultImgId) OR
-      (u.defaultImgId IS NULL AND ui.subId = u.userId AND ui.imgType = :imgType)
-      `,
-      { imgType: ImageType.User },
-    );
+    // Nested Entity에도 ImageInstanceManager#mapImage를 사용할 수 있넹??
+    this.imageManager.mapImage(queryBuilder, 'u');
 
     const fundingPromies: Promise<FundingDto>[] = await queryBuilder
       .getMany()

--- a/src/features/image/image-instance-manager.ts
+++ b/src/features/image/image-instance-manager.ts
@@ -1,9 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { IImageId } from 'src/interfaces/image-id.interface';
 import { ImageService } from './image.service';
 import { Image } from 'src/entities/image.entity';
 import { SelectQueryBuilder } from 'typeorm';
-import { T } from 'node_modules/@faker-js/faker/dist/airline-BnpeTvY9.cjs';
 import { ImageType } from 'src/enums/image-type.enum';
 import { User } from 'src/entities/user.entity';
 import { Funding } from 'src/entities/funding.entity';
@@ -36,7 +35,9 @@ export class ImageInstanceManager {
    * and image.imgType to the proper ImageType.
    *
    * @param qb    The TypeORM query builder for one of the entities.
-   * @param alias Optional alias for the entity in the query.
+   * @param alias 매핑하고 싶은 엔티티의 alias를 명시, e.g. mapImage(fundingQb, 'author')
+   * 2025-03-09 edit: 네스팅된 엔티티에도 사용가능! mapImage 하기 전에 연관 엔티티와 join을 수행해야 하겠죠?
+   *
    * @returns     The query builder with the left join mapped to the `image` property.
    * @see https://orkhan.gitbook.io/typeorm/docs/select-query-builder#joining-and-mapping-functionality
    * @example
@@ -48,11 +49,11 @@ export class ImageInstanceManager {
         'comment.isDel = :isDel',
         { isDel: false },
       )
-      .leftJoinAndSelect('comment.author', 'author')
+      .leftJoinAndSelect('comment.author', 'author') // *** funding.comment.'author'
       .where('funding.fundUuid = :fundUuid', { fundUuid })
       .orderBy('comment.regAt', 'DESC');
 
-    // NOTE - 이런 식으로 매핑하고 싶은 엔티티 alias를 붙여주면 됩니다.
+    // *** NOTE - 이런 식으로 매핑하고 싶은 엔티티 alias를 붙여주면 됩니다.
     this.imageInstanceManager.mapImage(fundingQb, 'author');
     this.imageInstanceManager.mapImage(fundingQb, 'funding');
 
@@ -65,7 +66,7 @@ export class ImageInstanceManager {
       .where('author.userId = :userId', { userId: user.userId! });
 
     // NOTE - 또는 아래와 같이 alias를 생략하면 query builder의 main alias가 자동으로 사용됩니다.
-    this.imageInstanceManager.mapImage(authorQb);
+    this.imageInstanceManager.mapImage(authorQb); // 'user'가 자동으로 설정.
    */
   mapImage(
     qb: SelectQueryBuilder<any>,


### PR DESCRIPTION
### PR 제목:
펀딩 및 이미지 매핑 로직 개선 및 리팩토링

### PR 내용:
펀딩 목록 조회 및 이미지 매핑 로직을 개선하여 코드의 가독성을 높이고, 불필요한 변수 선언 및 중복 로직을 제거하였습니다.

#### 주요 변경 사항:
1. **펀딩 목록 조회 최적화**
   - `funding.fundUser` 필터링 로직을 간소화.
   - 불필요한 `friendIdsArray` 변수 선언 제거.
   - `friendIds` 조회 시 `userId`를 재사용하여 코드 간결화.

2. **이미지 매핑 개선**
   - `ImageInstanceManager#mapImage`를 활용하여 네스팅된 엔티티에서도 이미지 매핑 가능하도록 개선.
   - `leftJoinAndMapOne`을 직접 사용하는 대신 `mapImage`를 호출하도록 변경.

3. **`mapImages` 메서드 개선**
   - 엔티티 타입을 자동 감지하여 `idField` 및 `imgType`을 동적으로 결정하도록 개선.
   - `leftJoinAndMapMany`를 활용하여 여러 이미지를 한 번에 매핑 가능하도록 변경.
   - `defaultImgId`가 존재할 경우 `imgId`를, 없을 경우 `subId`와 `imgType`을 활용해 매핑.

### 기대 효과:
- 코드 가독성 향상 및 유지보수성 증가.
- 불필요한 변수 및 중복 코드 제거로 성능 개선.
- `ImageInstanceManager`를 통해 이미지 매핑을 보다 일관성 있게 수행 가능.

검토 후 피드백 부탁드립니다! 🚀